### PR TITLE
A bunch of formatting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,11 @@ let package = Package(
         ),
         .target(
             name: "SwiftRoaring",
-            dependencies:["croaring"]
+            dependencies: ["croaring"]
         ),
         .testTarget(
             name: "swiftRoaringTests",
-            dependencies:["SwiftRoaring"]
+            dependencies: ["SwiftRoaring"]
         )
     ]
 )

--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -16,39 +16,39 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /////////////////////////////////////////////////////////////////////////////
     ///                             CONSTRUCTORS                              ///
     /////////////////////////////////////////////////////////////////////////////
-    /**
-     * Creates a new bitmap (initially empty)
-     */
+    ///
+    /// Creates a new bitmap (initially empty)
+    ///
     public init() {
         self.ptr = croaring.roaring_bitmap_create()!
     }
 
-    /**
-     * Creates a new bitmap using a given ptr
-     */
+    ///
+    /// Creates a new bitmap using a given ptr
+    ///
     private init(ptr: UnsafeMutablePointer<roaring_bitmap_t>) {
         self.ptr = ptr
     }
 
-    /**
-     * Add all the values between min (included) and max (excluded) that are at a
-     * distance k*step from min.
-     */
+    ///
+    /// Add all the values between min (included) and max (excluded) that are at a
+    /// distance k*step from min.
+    ///
     public init(min: UInt64, max: UInt64, step: UInt32) {
         self.ptr = croaring.roaring_bitmap_from_range(min, max, step)!
     }
 
-    /**
-     * Creates a new bitmap (initially empty) with a provided
-     * container-storage capacity (it is a performance hint).
-     */
+    ///
+    /// Creates a new bitmap (initially empty) with a provided
+    /// container-storage capacity (it is a performance hint).
+    ///
     public init(capacity: UInt32) {
         self.ptr = croaring.roaring_bitmap_create_with_capacity(capacity)!
     }
 
-    /**
-     * Creates a new bitmap from a pointer of uint32_t integers
-     */
+    ///
+    /// Creates a new bitmap from a pointer of uint32_t integers
+    ///
     public init(values: [UInt32]) {
         self.ptr = croaring.roaring_bitmap_of_ptr(values.count, values)!
     }
@@ -67,130 +67,130 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     ///                             OPERATORS                                 ///
     /////////////////////////////////////////////////////////////////////////////
 
-    /**
-     * Computes the intersection between two bitmaps and returns new bitmap. The
-     * caller is
-     * responsible for memory management.
-     *
-     */
+    ///
+    /// Computes the intersection between two bitmaps and returns new bitmap. The
+    /// caller is
+    /// responsible for memory management.
+    ///
+    ///
     public func intersection(_ x: RoaringBitmap) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_and(self.ptr, x.ptr))
     }
-    /**
-     * Computes the intersection between two bitmaps and returns new bitmap. The
-     * caller is
-     * responsible for memory management.
-     *
-     */
+    ///
+    /// Computes the intersection between two bitmaps and returns new bitmap. The
+    /// caller is
+    /// responsible for memory management.
+    ///
+    ///
     public static func &(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap {
         return left.intersection(right)
     }
 
-    /**
-     * Inplace version modifies x1, x1 == x2 is allowed
-     */
+    ///
+    /// Inplace version modifies x1, x1 == x2 is allowed
+    ///
     public func formIntersection(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_and_inplace(self.ptr, x.ptr)
     }
-    /**
-     * Inplace version modifies x1, x1 == x2 is allowed
-     */
+    ///
+    /// Inplace version modifies x1, x1 == x2 is allowed
+    ///
     public static func &=(left: RoaringBitmap, right: RoaringBitmap) {
         left.formIntersection(right)
     }
 
-    /**
-     * Computes the size of the intersection between two bitmaps.
-     *
-     */
+    ///
+    /// Computes the size of the intersection between two bitmaps.
+    ///
+    ///
     public func intersectionCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_and_cardinality(self.ptr, x.ptr)
     }
 
-    /**
-     * Check whether two bitmaps intersect.
-     *
-     */
+    ///
+    /// Check whether two bitmaps intersect.
+    ///
+    ///
     public func intersect(_ x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_intersect(self.ptr, x.ptr)
     }
 
-    /**
-     * Computes the Jaccard index between two bitmaps. (Also known as the Tanimoto
-     * distance,
-     * or the Jaccard similarity coefficient)
-     *
-     * The Jaccard index is undefined if both bitmaps are empty.
-     *
-     */
+    ///
+    /// Computes the Jaccard index between two bitmaps. (Also known as the Tanimoto
+    /// distance,
+    /// or the Jaccard similarity coefficient)
+    ///
+    /// The Jaccard index is undefined if both bitmaps are empty.
+    ///
+    ///
     public func jaccardIndex(_ x: RoaringBitmap) -> Double {
         return croaring.roaring_bitmap_jaccard_index(self.ptr, x.ptr)
     }
 
-    /**
-     * Computes the size of the union between two bitmaps.
-     *
-     */
+    ///
+    /// Computes the size of the union between two bitmaps.
+    ///
+    ///
     public func unionCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_or_cardinality(self.ptr, x.ptr)
     }
 
-    /**
-     * Computes the size of the difference (andnot) between two bitmaps.
-     *
-     */
+    ///
+    /// Computes the size of the difference (andnot) between two bitmaps.
+    ///
+    ///
     public func subtractingCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_andnot_cardinality(self.ptr, x.ptr)
     }
 
-    /**
-     * Returns the number of elements in range [min, max).
-     */
+    ///
+    /// Returns the number of elements in range [min, max).
+    ///
     public func rangeCardinality(min: UInt64, max: UInt64) -> UInt64 {
         return croaring.roaring_bitmap_range_cardinality(self.ptr, min, max)
     }
 
-    /**
-     * Computes the size of the symmetric difference (andnot) between two bitmaps.
-     *
-     */
+    ///
+    /// Computes the size of the symmetric difference (andnot) between two bitmaps.
+    ///
+    ///
     public func symmetricDifferenceCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_xor_cardinality(self.ptr, x.ptr)
     }
 
-    /**
-     * Computes the union between two bitmaps and returns new bitmap. The caller is
-     * responsible for memory management.
-     */
+    ///
+    /// Computes the union between two bitmaps and returns new bitmap. The caller is
+    /// responsible for memory management.
+    ///
     public func union(_ x: RoaringBitmap) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_or(self.ptr, x.ptr))
     }
-    /**
-     * Computes the union between two bitmaps and returns new bitmap. The caller is
-     * responsible for memory management.
-     */
+    ///
+    /// Computes the union between two bitmaps and returns new bitmap. The caller is
+    /// responsible for memory management.
+    ///
     public static func |(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap {
         return left.union(right)
     }
 
-    /**
-     * Inplace version of roaring_bitmap_or, modifies x1.
-     */
+    ///
+    /// Inplace version of roaring_bitmap_or, modifies x1.
+    ///
     public func formUnion(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_or_inplace(self.ptr, x.ptr)
     }
-    /**
-     * Inplace version of roaring_bitmap_or, modifies x1.
-     */
+    ///
+    /// Inplace version of roaring_bitmap_or, modifies x1.
+    ///
     public static func |=(left: RoaringBitmap, right: RoaringBitmap) {
         left.formUnion(right)
     }
 
-    /**
-     * Compute the union of 'number' bitmaps. See also roaring_bitmap_or_many_heap.
-     * Caller is responsible for freeing the
-     * result.
-     */
+    ///
+    /// Compute the union of 'number' bitmaps. See also roaring_bitmap_or_many_heap.
+    /// Caller is responsible for freeing the
+    /// result.
+    ///
 
     public func unionMany(_ xs: [RoaringBitmap]) -> RoaringBitmap {
         let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
@@ -200,13 +200,13 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         }
         return RoaringBitmap(ptr: croaring.roaring_bitmap_or_many(xs.count + 1, ptr))
     }
-    /**
-     * Compute the union of 'number' bitmaps using a heap. This can
-     * sometimes be faster than roaring_bitmap_or_many which uses
-     * a naive algorithm. Caller is responsible for freeing the
-     * result.
-     *
-     */
+    ///
+    /// Compute the union of 'number' bitmaps using a heap. This can
+    /// sometimes be faster than roaring_bitmap_or_many which uses
+    /// a naive algorithm. Caller is responsible for freeing the
+    /// result.
+    ///
+    ///
     public func unionManyHeap(_ xs: [RoaringBitmap]) -> RoaringBitmap {
         let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
         ptr[0] = UnsafePointer<roaring_bitmap_t>(self.ptr)
@@ -216,42 +216,42 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         return RoaringBitmap(ptr: croaring.roaring_bitmap_or_many_heap(UInt32(xs.count + 1), ptr))
     }
 
-    /**
-     * Computes the symmetric difference (xor) between two bitmaps
-     * and returns new bitmap. The caller is responsible for memory management.
-     */
+    ///
+    /// Computes the symmetric difference (xor) between two bitmaps
+    /// and returns new bitmap. The caller is responsible for memory management.
+    ///
     public func symmetricDifference(_ x: RoaringBitmap) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_xor(self.ptr, x.ptr))
     }
-    /**
-     * Computes the symmetric difference (xor) between two bitmaps
-     * and returns new bitmap. The caller is responsible for memory management.
-     */
+    ///
+    /// Computes the symmetric difference (xor) between two bitmaps
+    /// and returns new bitmap. The caller is responsible for memory management.
+    ///
     public static func ^(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap {
         return left.symmetricDifference(right)
     }
 
-    /**
-     * Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
-     *
-     */
+    ///
+    /// Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
+    ///
+    ///
     public func formSymmetricDifference(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_xor_inplace(self.ptr, x.ptr)
     }
-    /**
-     * Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
-     *
-     */
+    ///
+    /// Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
+    ///
+    ///
     public static func ^=(left: RoaringBitmap, right: RoaringBitmap) {
         left.formSymmetricDifference(right)
     }
 
-    /**
-     * Compute the xor of 'number' bitmaps.
-     * Caller is responsible for freeing the
-     * result.
-     *
-     */
+    ///
+    /// Compute the xor of 'number' bitmaps.
+    /// Caller is responsible for freeing the
+    /// result.
+    ///
+    ///
     public func symmetricDifferenceMany(_ xs: [RoaringBitmap]) -> RoaringBitmap {
         let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
         ptr[0] = UnsafePointer<roaring_bitmap_t>(self.ptr)
@@ -261,140 +261,140 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         return RoaringBitmap(ptr: croaring.roaring_bitmap_xor_many(xs.count + 1, ptr))
     }
 
-    /**
-     * Computes the  difference (andnot) between two bitmaps
-     * and returns new bitmap. The caller is responsible for memory management.
-     */
+    ///
+    /// Computes the  difference (andnot) between two bitmaps
+    /// and returns new bitmap. The caller is responsible for memory management.
+    ///
     public func subtracting(_ x: RoaringBitmap) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_andnot(self.ptr, x.ptr))
     }
-    /**
-     * Computes the  difference (andnot) between two bitmaps
-     * and returns new bitmap. The caller is responsible for memory management.
-     */
+    ///
+    /// Computes the  difference (andnot) between two bitmaps
+    /// and returns new bitmap. The caller is responsible for memory management.
+    ///
     public static func -(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap {
         return left.subtracting(right)
     }
 
-    /**
-     * Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
-     *
-     */
+    ///
+    /// Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
+    ///
+    ///
     public func subtract(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_andnot_inplace(self.ptr, x.ptr)
     }
-    /**
-     * Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
-     *
-     */
+    ///
+    /// Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
+    ///
+    ///
     public static func -=(left: RoaringBitmap, right: RoaringBitmap) {
         left.subtract(right)
     }
 
-    /**
-     * Return true if the two bitmaps contain the same elements.
-     */
-    /**
-     * Return true if the two bitmaps contain the same elements.
-     */
+    ///
+    /// Return true if the two bitmaps contain the same elements.
+    ///
+    ///
+    /// Return true if the two bitmaps contain the same elements.
+    ///
     public static func ==(left: RoaringBitmap, right: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_equals(left.ptr, right.ptr)
     }
 
-    /**
-     * Return true if all the elements of ra1 are also in ra2.
-     */
+    ///
+    /// Return true if all the elements of ra1 are also in ra2.
+    ///
     public func isSubset(of x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_is_subset(self.ptr, x.ptr)
     }
 
-    /**
-     * Return true if all the elements of ra1 are also in ra2 and ra2 is strictly
-     * greater
-     * than ra1.
-     */
+    ///
+    /// Return true if all the elements of ra1 are also in ra2 and ra2 is strictly
+    /// greater
+    /// than ra1.
+    ///
     public func isStrictSubset(of x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_is_strict_subset(self.ptr, x.ptr)
     }
 
-    /**
-     * (For expert users who seek high performance.)
-     *
-     * Computes the union between two bitmaps and returns new bitmap. The caller is
-     * responsible for memory management.
-     *
-     * The lazy version defers some computations such as the maintenance of the
-     * cardinality counts. Thus you need
-     * to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
-     * It is safe to repeatedly call roaring_bitmap_lazy_or_inplace on the result.
-     * The bitsetconversion conversion is a flag which determines
-     * whether container-container operations force a bitset conversion.
-     **/
+    ///
+    /// (For expert users who seek high performance.)
+    ///
+    /// Computes the union between two bitmaps and returns new bitmap. The caller is
+    /// responsible for memory management.
+    ///
+    /// The lazy version defers some computations such as the maintenance of the
+    /// cardinality counts. Thus you need
+    /// to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
+    /// It is safe to repeatedly call roaring_bitmap_lazy_or_inplace on the result.
+    /// The bitsetconversion conversion is a flag which determines
+    /// whether container-container operations force a bitset conversion.
+    ///
     public func lazyUnion(_ x: RoaringBitmap, bitsetconversion: Bool) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_or(self.ptr, x.ptr, bitsetconversion))
     }
 
-    /**
-     * (For expert users who seek high performance.)
-     * Inplace version of roaring_bitmap_lazy_or, modifies x1
-     * The bitsetconversion conversion is a flag which determines
-     * whether container-container operations force a bitset conversion.
-     */
+    ///
+    /// (For expert users who seek high performance.)
+    /// Inplace version of roaring_bitmap_lazy_or, modifies x1
+    /// The bitsetconversion conversion is a flag which determines
+    /// whether container-container operations force a bitset conversion.
+    ///
     public func formLazyUnion(_ x: RoaringBitmap, bitsetconversion: Bool) {
         croaring.roaring_bitmap_lazy_or_inplace(self.ptr, x.ptr, bitsetconversion)
     }
 
-    /**
-     * (For expert users who seek high performance.)
-     *
-     * Execute maintenance operations on a bitmap created from
-     * roaring_bitmap_lazy_or
-     * or modified with roaring_bitmap_lazy_or_inplace.
-     */
+    ///
+    /// (For expert users who seek high performance.)
+    ///
+    /// Execute maintenance operations on a bitmap created from
+    /// roaring_bitmap_lazy_or
+    /// or modified with roaring_bitmap_lazy_or_inplace.
+    ///
     public func repairAfterLazy() {
         croaring.roaring_bitmap_repair_after_lazy(self.ptr)
     }
 
-    /**
-     * Computes the symmetric difference between two bitmaps and returns new bitmap.
-     *The caller is
-     * responsible for memory management.
-     *
-     * The lazy version defers some computations such as the maintenance of the
-     * cardinality counts. Thus you need
-     * to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
-     * It is safe to repeatedly call roaring_bitmap_lazy_xor_inplace on the result.
-     *
-     */
+    ///
+    /// Computes the symmetric difference between two bitmaps and returns new bitmap.
+    /// The caller is
+    /// responsible for memory management.
+    ///
+    /// The lazy version defers some computations such as the maintenance of the
+    /// cardinality counts. Thus you need
+    /// to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
+    /// It is safe to repeatedly call roaring_bitmap_lazy_xor_inplace on the result.
+    ///
+    ///
     public func lazySymmetricDifference(_ x: RoaringBitmap) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_xor(self.ptr, x.ptr))
     }
 
-    /**
-     * (For expert users who seek high performance.)
-     * Inplace version of roaring_bitmap_lazy_xor, modifies x1. x1 != x2
-     *
-     */
+    ///
+    /// (For expert users who seek high performance.)
+    /// Inplace version of roaring_bitmap_lazy_xor, modifies x1. x1 != x2
+    ///
+    ///
     public func formLazySymmetricDifference(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_lazy_xor_inplace(self.ptr, x.ptr)
     }
 
-    /**
-     * compute the negation of the roaring bitmap within a specified
-     * interval: [range_start, range_end). The number of negated values is
-     * range_end - range_start.
-     * Areas outside the range are passed through unchanged.
-     */
+    ///
+    /// compute the negation of the roaring bitmap within a specified
+    /// interval: [range_start, range_end). The number of negated values is
+    /// range_end - range_start.
+    /// Areas outside the range are passed through unchanged.
+    ///
     public func flip(rangeStart: UInt64, rangeEnd: UInt64) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_flip(self.ptr, rangeStart, rangeEnd))
     }
 
-    /**
-     * compute (in place) the negation of the roaring bitmap within a specified
-     * interval: [range_start, range_end). The number of negated values is
-     * range_end - range_start.
-     * Areas outside the range are passed through unchanged.
-     */
+    ///
+    /// compute (in place) the negation of the roaring bitmap within a specified
+    /// interval: [range_start, range_end). The number of negated values is
+    /// range_end - range_start.
+    /// Areas outside the range are passed through unchanged.
+    ///
     public func flipInplace(rangeStart: UInt64, rangeEnd: UInt64) {
         croaring.roaring_bitmap_flip_inplace(self.ptr, rangeStart, rangeEnd)
     }
@@ -403,80 +403,80 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /////////////////////////////////////////////////////////////////////////////
     /////////////////////////////////////////////////////////////////////////////
 
-    /**
-     * Copies a  bitmap. This does memory allocation. The caller is responsible for
-     * memory management.
-     *
-     */
+    ///
+    /// Copies a  bitmap. This does memory allocation. The caller is responsible for
+    /// memory management.
+    ///
+    ///
     public func copy() -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_copy(self.ptr))
     }
 
-    /**
-     * Copies a  bitmap from src to dest. It is assumed that the pointer dest
-     * is to an already allocated bitmap. The content of the dest bitmap is
-     * freed/deleted.
-     *
-     * It might be preferable and simpler to call roaring_bitmap_copy except
-     * that roaring_bitmap_overwrite can save on memory allocations.
-     *
-     */
+    ///
+    /// Copies a  bitmap from src to dest. It is assumed that the pointer dest
+    /// is to an already allocated bitmap. The content of the dest bitmap is
+    /// freed/deleted.
+    ///
+    /// It might be preferable and simpler to call roaring_bitmap_copy except
+    /// that roaring_bitmap_overwrite can save on memory allocations.
+    ///
+    ///
     // func overwrite(dest: RoaringBitmap) -> Bool {
     //     return croaring.roaring_bitmap_overwrite(dest.ptr, self.ptr)
     // }
 
-    /**
-     * Add value x
-     *
-     */
+    ///
+    /// Add value x
+    ///
+    ///
     public func add(_ value: UInt32) {
         croaring.roaring_bitmap_add(self.ptr, value)
     }
 
-    /**
-     * Add value n_args from pointer vals, faster than repeatedly calling
-     * roaring_bitmap_add
-     *
-     */
+    ///
+    /// Add value n_args from pointer vals, faster than repeatedly calling
+    /// roaring_bitmap_add
+    ///
+    ///
     public func addMany(values: [UInt32]) {
         croaring.roaring_bitmap_add_many(self.ptr, values.count, values)
     }
 
-    /**
-     * Add value x
-     * Returns true if a new value was added, false if the value was already existing.
-     */
+    ///
+    /// Add value x
+    /// Returns true if a new value was added, false if the value was already existing.
+    ///
     public func addCheck(_ value: UInt32) -> Bool {
         return croaring.roaring_bitmap_add_checked(self.ptr, value)
     }
 
-    /**
-     * Add all values in range [min, max]
-     */
+    ///
+    /// Add all values in range [min, max]
+    ///
     public func addRangeClosed(min: UInt32, max: UInt32) {
         croaring.roaring_bitmap_add_range_closed(self.ptr, min, max)
     }
 
-    /**
-     * Add all values in range [min, max)
-     */
+    ///
+    /// Add all values in range [min, max)
+    ///
     public func addRange(min: UInt64, max: UInt64) {
         croaring.roaring_bitmap_add_range(self.ptr, min, max)
     }
 
-    /**
-     * Remove value x
-     */
+    ///
+    /// Remove value x
+    ///
     public func remove(_ value: UInt32) {
         croaring.roaring_bitmap_remove(self.ptr, value)
     }
 
-    /** Remove all values in range [min, max] */
+    /// Remove all values in range [min, max] */
     public func removeRangeClosed(min: UInt32, max: UInt32) {
         croaring.roaring_bitmap_remove_range_closed(self.ptr, min, max)
     }
 
-    /** Remove all values in range [min, max) */
+    /// Remove all values in range [min, max) */
     public func removeRange(min: UInt64, max: UInt64) {
         croaring.roaring_bitmap_remove_range(self.ptr, min, max)
     }
@@ -487,76 +487,76 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     //     croaring.roaring_bitmap_remove_many(self.ptr, n_args, ptr)
     // }
 
-    /**
-     * Remove value x
-     * Returns true if a new value was removed, false if the value was not existing.
-     */
+    ///
+    /// Remove value x
+    /// Returns true if a new value was removed, false if the value was not existing.
+    ///
     public func removeCheck(_ value: UInt32) -> Bool {
         return croaring.roaring_bitmap_remove_checked(self.ptr, value)
     }
 
-    /**
-     * Frees the memory.
-     */
+    ///
+    /// Frees the memory.
+    ///
     private func free() {
         croaring.roaring_bitmap_free(self.ptr)
     }
 
-    /**
-     * Empties the bitmap.
-     */
+    ///
+    /// Empties the bitmap.
+    ///
     public func clear() {
         croaring.roaring_bitmap_clear(self.ptr)
     }
 
-    /**
-     * Get the cardinality of the bitmap (number of elements).
-     */
+    ///
+    /// Get the cardinality of the bitmap (number of elements).
+    ///
     public var count: UInt64 {
         return croaring.roaring_bitmap_get_cardinality(self.ptr)
     }
 
-    /**
-     * Check if value x is present
-     */
+    ///
+    /// Check if value x is present
+    ///
     public func contains(_ value: UInt32) -> Bool {
         return croaring.roaring_bitmap_contains(self.ptr, value)
     }
 
-    /**
-     * Check whether a range of values from range_start (included) to range_end (excluded) is present
-     */
+    ///
+    /// Check whether a range of values from range_start (included) to range_end (excluded) is present
+    ///
     public func containsRange(start: UInt64, end: UInt64) -> Bool {
         return croaring.roaring_bitmap_contains_range(self.ptr, start, end)
     }
-    /**
-     * Check whether the bitmap is empty
-     */
+    ///
+    /// Check whether the bitmap is empty
+    ///
     public var isEmpty: Bool {
         return croaring.roaring_bitmap_is_empty(self.ptr)
     }
 
-    /**
-     * Print the content of the bitmap.
-     */
+    ///
+    /// Print the content of the bitmap.
+    ///
     public func print() {
         croaring.roaring_bitmap_printf(self.ptr)
     }
 
-    /**
-     * Describe the inner structure of the bitmap.
-     */
+    ///
+    /// Describe the inner structure of the bitmap.
+    ///
     public func describe() {
         croaring.roaring_bitmap_printf_describe(self.ptr)
     }
 
-    /**
-     * Convert the bitmap to an array. Write the output to "ans",
-     * caller is responsible to ensure that there is enough memory
-     * allocated
-     * (e.g., ans = malloc(roaring_bitmap_get_cardinality(mybitmap)
-     *   * sizeof(uint32_t))
-     */
+    ///
+    /// Convert the bitmap to an array. Write the output to "ans",
+    /// caller is responsible to ensure that there is enough memory
+    /// allocated
+    /// (e.g., ans = malloc(roaring_bitmap_get_cardinality(mybitmap)
+    ///   * sizeof(uint32_t))
+    ///
     public func toArray() -> [UInt32] {
         let count = (Int(self.count) * MemoryLayout<UInt32>.size)/4
         var array = [UInt32](repeating: 0, count: count)
@@ -580,164 +580,164 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     //     return array
     // }
 
-    /**
-     *  Remove run-length encoding even when it is more space efficient
-     *  return whether a change was applied
-     */
+    ///
+    ///  Remove run-length encoding even when it is more space efficient
+    ///  return whether a change was applied
+    ///
 
     public func removeRunCompression() -> Bool {
         return croaring.roaring_bitmap_remove_run_compression(self.ptr)
     }
 
-    /** convert array and bitmap containers to run containers when it is more
-     * efficient;
-     * also convert from run containers when more space efficient.  Returns
-     * true if the result has at least one run container.
-     * Additional savings might be possible by calling shrinkToFit().
-     */
+    /// convert array and bitmap containers to run containers when it is more
+    /// efficient;
+    /// also convert from run containers when more space efficient.  Returns
+    /// true if the result has at least one run container.
+    /// Additional savings might be possible by calling shrinkToFit().
+    ///
     public func runOptimize() -> Bool {
         return croaring.roaring_bitmap_run_optimize(self.ptr)
     }
 
-    /**
-     * If needed, reallocate memory to shrink the memory usage. Returns
-     * the number of bytes saved.
-     */
+    ///
+    /// If needed, reallocate memory to shrink the memory usage. Returns
+    /// the number of bytes saved.
+    ///
     public func shrink() -> size_t {
         return croaring.roaring_bitmap_shrink_to_fit(self.ptr)
     }
 
-    /**
-     * write the bitmap to an output pointer, this output buffer should refer to
-     * at least roaring_bitmap_size_in_bytes(ra) allocated bytes.
-     *
-     * see roaring_bitmap_portable_serialize if you want a format that's compatible
-     * with Java and Go implementations
-     *
-     * this format has the benefit of being sometimes more space efficient than
-     * roaring_bitmap_portable_serialize
-     * e.g., when the data is sparse.
-     *
-     * Returns how many bytes were written which should be
-     * roaring_bitmap_size_in_bytes(ra).
-     */
+    ///
+    /// write the bitmap to an output pointer, this output buffer should refer to
+    /// at least roaring_bitmap_size_in_bytes(ra) allocated bytes.
+    ///
+    /// see roaring_bitmap_portable_serialize if you want a format that's compatible
+    /// with Java and Go implementations
+    ///
+    /// this format has the benefit of being sometimes more space efficient than
+    /// roaring_bitmap_portable_serialize
+    /// e.g., when the data is sparse.
+    ///
+    /// Returns how many bytes were written which should be
+    /// roaring_bitmap_size_in_bytes(ra).
+    ///
     public func serialize(buffer: inout [Int8]) -> size_t {
         return croaring.roaring_bitmap_serialize(self.ptr, &buffer)
     }
 
-    /**  use with roaring_bitmap_serialize
-     * see roaring_bitmap_portable_deserialize if you want a format that's
-     * compatible with Java and Go implementations
-     */
+    /// use with roaring_bitmap_serialize
+    /// see roaring_bitmap_portable_deserialize if you want a format that's
+    /// compatible with Java and Go implementations
+    ///
     public static func deserialize(buffer: [Int8]) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_deserialize(buffer)!)
     }
 
-    /**
-     * How many bytes are required to serialize this bitmap (NOT compatible
-     * with Java and Go versions)
-     */
+    ///
+    /// How many bytes are required to serialize this bitmap (NOT compatible
+    /// with Java and Go versions)
+    ///
     public func sizeInBytes() -> size_t {
         return croaring.roaring_bitmap_size_in_bytes(self.ptr)
     }
 
-    /**
-     * read a bitmap from a serialized version. This is meant to be compatible with
-     * the Java and Go versions. See format specification at
-     * https://github.com/RoaringBitmap/RoaringFormatSpec
-     * In case of failure, a null pointer is returned.
-     * This function is unsafe in the sense that if there is no valid serialized
-     * bitmap at the pointer, then many bytes could be read, possibly causing a buffer
-     * overflow. For a safer approach,
-     * call roaring_bitmap_portable_deserialize_safe.
-     */
+    ///
+    /// read a bitmap from a serialized version. This is meant to be compatible with
+    /// the Java and Go versions. See format specification at
+    /// https://github.com/RoaringBitmap/RoaringFormatSpec
+    /// In case of failure, a null pointer is returned.
+    /// This function is unsafe in the sense that if there is no valid serialized
+    /// bitmap at the pointer, then many bytes could be read, possibly causing a buffer
+    /// overflow. For a safer approach,
+    /// call roaring_bitmap_portable_deserialize_safe.
+    ///
     public static func portableDeserialize(buffer: [Int8]) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_portable_deserialize(buffer)!)
     }
 
-    /**
-     * read a bitmap from a serialized version in a safe manner (reading up to maxbytes).
-     * This is meant to be compatible with
-     * the Java and Go versions. See format specification at
-     * https://github.com/RoaringBitmap/RoaringFormatSpec
-     * In case of failure, a null pointer is returned.
-     */
+    ///
+    /// read a bitmap from a serialized version in a safe manner (reading up to maxbytes).
+    /// This is meant to be compatible with
+    /// the Java and Go versions. See format specification at
+    /// https://github.com/RoaringBitmap/RoaringFormatSpec
+    /// In case of failure, a null pointer is returned.
+    ///
     public static func portableDeserializeSafe(buffer: [Int8], maxbytes: size_t) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_portable_deserialize_safe(buffer, maxbytes)!)
     }
 
-    /**
-     * Check how many bytes would be read (up to maxbytes) at this pointer if there
-     * is a bitmap, returns zero if there is no valid bitmap.
-     * This is meant to be compatible with
-     * the Java and Go versions. See format specification at
-     * https://github.com/RoaringBitmap/RoaringFormatSpec
-     */
+    ///
+    /// Check how many bytes would be read (up to maxbytes) at this pointer if there
+    /// is a bitmap, returns zero if there is no valid bitmap.
+    /// This is meant to be compatible with
+    /// the Java and Go versions. See format specification at
+    /// https://github.com/RoaringBitmap/RoaringFormatSpec
+    ///
     public static func portableDeserializeSize(buffer: [Int8], maxbytes: size_t) -> size_t {
         return croaring.roaring_bitmap_portable_deserialize_size(buffer, maxbytes)
     }
 
-    /**
-     * How many bytes are required to serialize this bitmap (meant to be compatible
-     * with Java and Go versions).  See format specification at
-     * https://github.com/RoaringBitmap/RoaringFormatSpec
-     */
+    ///
+    /// How many bytes are required to serialize this bitmap (meant to be compatible
+    /// with Java and Go versions).  See format specification at
+    /// https://github.com/RoaringBitmap/RoaringFormatSpec
+    ///
     public func portableSizeInBytes() -> size_t {
         return croaring.roaring_bitmap_portable_size_in_bytes(self.ptr)
     }
 
-    /**
-     * write a bitmap to a char buffer.  The output buffer should refer to at least
-     *  roaring_bitmap_portable_size_in_bytes(ra) bytes of allocated memory.
-     * This is meant to be compatible with
-     * the
-     * Java and Go versions. Returns how many bytes were written which should be
-     * roaring_bitmap_portable_size_in_bytes(ra).  See format specification at
-     * https://github.com/RoaringBitmap/RoaringFormatSpec
-     */
+    ///
+    /// write a bitmap to a char buffer.  The output buffer should refer to at least
+    ///  roaring_bitmap_portable_size_in_bytes(ra) bytes of allocated memory.
+    /// This is meant to be compatible with
+    /// the
+    /// Java and Go versions. Returns how many bytes were written which should be
+    /// roaring_bitmap_portable_size_in_bytes(ra).  See format specification at
+    /// https://github.com/RoaringBitmap/RoaringFormatSpec
+    ///
     public func portableSerialize(buffer: inout [Int8]) -> size_t {
         return croaring.roaring_bitmap_portable_serialize(self.ptr, &buffer)
     }
 
-    /**
-     * If the size of the roaring bitmap is strictly greater than rank, then this
-     function returns true and set the value to the the given rank.
-     Otherwise, it returns false.
-     */
+    ///
+    /// If the size of the roaring bitmap is strictly greater than rank, then this
+    /// function returns true and set the value to the the given rank.
+    /// Otherwise, it returns false.
+    ///
     public func select(rank: UInt32, value: UInt32) -> Bool {
         var cpy = value
         return croaring.roaring_bitmap_select(self.ptr, rank, &cpy)
     }
 
-    /**
-     * roaring_bitmap_rank returns the number of integers that are smaller or equal
-     * to x.
-     */
+    ///
+    /// roaring_bitmap_rank returns the number of integers that are smaller or equal
+    /// to x.
+    ///
     public func rank(value: UInt32) -> UInt64 {
         return croaring.roaring_bitmap_rank(self.ptr, value)
     }
 
-    /**
-     * roaring_bitmap_smallest returns the smallest value in the set.
-     * Returns UINT32_MAX if the set is empty.
-     */
+    ///
+    /// roaring_bitmap_smallest returns the smallest value in the set.
+    /// Returns UINT32_MAX if the set is empty.
+    ///
     public func min() -> UInt32 {
         return croaring.roaring_bitmap_minimum(self.ptr)
     }
 
-    /**
-     * roaring_bitmap_smallest returns the greatest value in the set.
-     * Returns 0 if the set is empty.
-     */
+    ///
+    /// roaring_bitmap_smallest returns the greatest value in the set.
+    /// Returns 0 if the set is empty.
+    ///
     public func max() -> UInt32 {
         return croaring.roaring_bitmap_maximum(self.ptr)
     }
 
-    /**
-     *  (For advanced users.)
-     * Collect statistics about the bitmap, see RoaringStatistics.swift for
-     * a description of RoaringStatistics
-     */
+    ///
+    ///  (For advanced users.)
+    /// Collect statistics about the bitmap, see RoaringStatistics.swift for
+    /// a description of RoaringStatistics
+    ///
 
     public func statistics() -> RoaringStatistics {
         var stats = RoaringStatistics()
@@ -745,16 +745,16 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         return stats
     }
 
-    /**
-     * Creates a RoaringBitmapIterator.
-     */
+    ///
+    /// Creates a RoaringBitmapIterator.
+    ///
     public func makeIterator() -> RoaringBitmapIterator {
         return RoaringBitmapIterator(ptr: self.ptr)
     }
 
-    /**
-     * code used to iterate through values in a roaring bitmap
-     */
+    ///
+    /// code used to iterate through values in a roaring bitmap
+    ///
     public struct RoaringBitmapIterator: IteratorProtocol {
         private var i: UnsafeMutablePointer<roaring_uint32_iterator_t>
 

--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -74,8 +74,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      *
      */
     public func intersection(_ x: RoaringBitmap) -> RoaringBitmap {
-        let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_and(self.ptr, x.ptr))
-        return x2
+        return RoaringBitmap(ptr: croaring.roaring_bitmap_and(self.ptr, x.ptr))
     }
     /**
      * Computes the intersection between two bitmaps and returns new bitmap. The
@@ -164,8 +163,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      * responsible for memory management.
      */
     public func union(_ x: RoaringBitmap) -> RoaringBitmap {
-        let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_or(self.ptr, x.ptr))
-        return x2
+        return RoaringBitmap(ptr: croaring.roaring_bitmap_or(self.ptr, x.ptr))
     }
     /**
      * Computes the union between two bitmaps and returns new bitmap. The caller is
@@ -223,8 +221,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      * and returns new bitmap. The caller is responsible for memory management.
      */
     public func symmetricDifference(_ x: RoaringBitmap) -> RoaringBitmap {
-        let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_xor(self.ptr, x.ptr))
-        return x2
+        return RoaringBitmap(ptr: croaring.roaring_bitmap_xor(self.ptr, x.ptr))
     }
     /**
      * Computes the symmetric difference (xor) between two bitmaps
@@ -269,8 +266,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      * and returns new bitmap. The caller is responsible for memory management.
      */
     public func subtracting(_ x: RoaringBitmap) -> RoaringBitmap {
-        let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_andnot(self.ptr, x.ptr))
-        return x2
+        return RoaringBitmap(ptr: croaring.roaring_bitmap_andnot(self.ptr, x.ptr))
     }
     /**
      * Computes the  difference (andnot) between two bitmaps
@@ -344,8 +340,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      * whether container-container operations force a bitset conversion.
      **/
     public func lazyUnion(_ x: RoaringBitmap, bitsetconversion: Bool) -> RoaringBitmap {
-        let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_or(self.ptr, x.ptr, bitsetconversion))
-        return x2
+        return RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_or(self.ptr, x.ptr, bitsetconversion))
     }
 
     /**
@@ -381,8 +376,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      *
      */
     public func lazySymmetricDifference(_ x: RoaringBitmap) -> RoaringBitmap {
-        let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_xor(self.ptr, x.ptr))
-        return x2
+        return RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_xor(self.ptr, x.ptr))
     }
 
     /**
@@ -401,8 +395,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      * Areas outside the range are passed through unchanged.
      */
     public func flip(rangeStart: UInt64, rangeEnd: UInt64) -> RoaringBitmap {
-        let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_flip(self.ptr, rangeStart, rangeEnd))
-        return x2
+        return RoaringBitmap(ptr: croaring.roaring_bitmap_flip(self.ptr, rangeStart, rangeEnd))
     }
 
     /**
@@ -425,8 +418,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      *
      */
     public func copy() -> RoaringBitmap {
-        let cpy = RoaringBitmap(ptr: croaring.roaring_bitmap_copy(self.ptr))
-        return cpy
+        return RoaringBitmap(ptr: croaring.roaring_bitmap_copy(self.ptr))
     }
 
     /**

--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -792,18 +792,13 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
 
     /* hash value for the bitset, this is expensive and should be buffered
      for performance */
-    public var hashValue: Int {
+    public func hash(into hasher: inout Hasher) {
         let b: UInt32 = 31
         var hash: UInt32 = 0
         for i in self {
             hash = hash &* b &+ i
         }
-        return Int(truncatingIfNeeded: hash)
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        for i in self {
-            i.hash(into: &hasher)
-        }
+        let hashValue = Int(truncatingIfNeeded: hash)
+        hashValue.hash(into: &hasher)
     }
 }

--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -1,15 +1,15 @@
 import croaring
 
 /**
-* This class contains different values about a given RoaringBitmap
-*/
+ * This class contains different values about a given RoaringBitmap
+ */
 public typealias RoaringStatistics = roaring_statistics_t
 
 /**
-* Swift wrapper for CRoaring (a C/C++ implementation at https://github.com/RoaringBitmap/CRoaring)
-*/
+ * Swift wrapper for CRoaring (a C/C++ implementation at https://github.com/RoaringBitmap/CRoaring)
+ */
 public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
-                           Hashable, ExpressibleByArrayLiteral  {
+                            Hashable, ExpressibleByArrayLiteral {
     var ptr: UnsafeMutablePointer<roaring_bitmap_t>
     public typealias Element = UInt32
 
@@ -17,38 +17,38 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     ///                             CONSTRUCTORS                              ///
     /////////////////////////////////////////////////////////////////////////////
     /**
-    * Creates a new bitmap (initially empty)
-    */
+     * Creates a new bitmap (initially empty)
+     */
     public init() {
         self.ptr = croaring.roaring_bitmap_create()!
     }
 
     /**
-    * Creates a new bitmap using a given ptr
-    */
+     * Creates a new bitmap using a given ptr
+     */
     private init(ptr: UnsafeMutablePointer<roaring_bitmap_t>) {
         self.ptr = ptr
     }
 
     /**
-    * Add all the values between min (included) and max (excluded) that are at a
-    * distance k*step from min.
-    */
+     * Add all the values between min (included) and max (excluded) that are at a
+     * distance k*step from min.
+     */
     public init(min: UInt64, max: UInt64, step: UInt32) {
         self.ptr = croaring.roaring_bitmap_from_range(min, max, step)!
     }
 
     /**
-    * Creates a new bitmap (initially empty) with a provided
-    * container-storage capacity (it is a performance hint).
-    */
+     * Creates a new bitmap (initially empty) with a provided
+     * container-storage capacity (it is a performance hint).
+     */
     public init(capacity: UInt32) {
         self.ptr = croaring.roaring_bitmap_create_with_capacity(capacity)!
     }
 
     /**
-    * Creates a new bitmap from a pointer of uint32_t integers
-    */
+     * Creates a new bitmap from a pointer of uint32_t integers
+     */
     public init(values: [UInt32]) {
         self.ptr = croaring.roaring_bitmap_of_ptr(values.count, values)!
     }
@@ -63,148 +63,147 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         self.free()
     }
 
-
     /////////////////////////////////////////////////////////////////////////////
     ///                             OPERATORS                                 ///
     /////////////////////////////////////////////////////////////////////////////
 
     /**
-    * Computes the intersection between two bitmaps and returns new bitmap. The
-    * caller is
-    * responsible for memory management.
-    *
-    */
+     * Computes the intersection between two bitmaps and returns new bitmap. The
+     * caller is
+     * responsible for memory management.
+     *
+     */
     public func intersection(_ x: RoaringBitmap) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_and(self.ptr, x.ptr))
         return x2
     }
     /**
-    * Computes the intersection between two bitmaps and returns new bitmap. The
-    * caller is
-    * responsible for memory management.
-    *
-    */
-    public static func &(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap{
+     * Computes the intersection between two bitmaps and returns new bitmap. The
+     * caller is
+     * responsible for memory management.
+     *
+     */
+    public static func &(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap {
         return left.intersection(right)
     }
 
     /**
-    * Inplace version modifies x1, x1 == x2 is allowed
-    */
+     * Inplace version modifies x1, x1 == x2 is allowed
+     */
     public func formIntersection(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_and_inplace(self.ptr, x.ptr)
 
     }
     /**
-    * Inplace version modifies x1, x1 == x2 is allowed
-    */
-    public static func &=(left: RoaringBitmap, right: RoaringBitmap){
+     * Inplace version modifies x1, x1 == x2 is allowed
+     */
+    public static func &=(left: RoaringBitmap, right: RoaringBitmap) {
         left.formIntersection(right)
     }
 
     /**
-    * Computes the size of the intersection between two bitmaps.
-    *
-    */
+     * Computes the size of the intersection between two bitmaps.
+     *
+     */
     public func intersectionCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_and_cardinality(self.ptr, x.ptr)
 
     }
 
     /**
-    * Check whether two bitmaps intersect.
-    *
-    */
+     * Check whether two bitmaps intersect.
+     *
+     */
     public func intersect(_ x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_intersect(self.ptr, x.ptr)
 
     }
 
     /**
-    * Computes the Jaccard index between two bitmaps. (Also known as the Tanimoto
-    * distance,
-    * or the Jaccard similarity coefficient)
-    *
-    * The Jaccard index is undefined if both bitmaps are empty.
-    *
-    */
+     * Computes the Jaccard index between two bitmaps. (Also known as the Tanimoto
+     * distance,
+     * or the Jaccard similarity coefficient)
+     *
+     * The Jaccard index is undefined if both bitmaps are empty.
+     *
+     */
     public func jaccardIndex(_ x: RoaringBitmap) -> Double {
         return croaring.roaring_bitmap_jaccard_index(self.ptr, x.ptr)
 
     }
 
     /**
-    * Computes the size of the union between two bitmaps.
-    *
-    */
+     * Computes the size of the union between two bitmaps.
+     *
+     */
     public func unionCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_or_cardinality(self.ptr, x.ptr)
 
     }
 
     /**
-    * Computes the size of the difference (andnot) between two bitmaps.
-    *
-    */
+     * Computes the size of the difference (andnot) between two bitmaps.
+     *
+     */
     public func subtractingCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_andnot_cardinality(self.ptr, x.ptr)
 
     }
 
     /**
-    * Returns the number of elements in range [min, max).
-    */
-    public func rangeCardinality(min: UInt64, max: UInt64) -> UInt64  {
+     * Returns the number of elements in range [min, max).
+     */
+    public func rangeCardinality(min: UInt64, max: UInt64) -> UInt64 {
         return croaring.roaring_bitmap_range_cardinality(self.ptr, min, max)
     }
 
     /**
-    * Computes the size of the symmetric difference (andnot) between two bitmaps.
-    *
-    */
+     * Computes the size of the symmetric difference (andnot) between two bitmaps.
+     *
+     */
     public func symmetricDifferenceCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_xor_cardinality(self.ptr, x.ptr)
 
     }
 
     /**
-    * Computes the union between two bitmaps and returns new bitmap. The caller is
-    * responsible for memory management.
-    */
+     * Computes the union between two bitmaps and returns new bitmap. The caller is
+     * responsible for memory management.
+     */
     public func union(_ x: RoaringBitmap) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_or(self.ptr, x.ptr))
         return x2
 
     }
     /**
-    * Computes the union between two bitmaps and returns new bitmap. The caller is
-    * responsible for memory management.
-    */
-    public static func |(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap{
+     * Computes the union between two bitmaps and returns new bitmap. The caller is
+     * responsible for memory management.
+     */
+    public static func |(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap {
         return left.union(right)
     }
 
     /**
-    * Inplace version of roaring_bitmap_or, modifies x1.
-    */
+     * Inplace version of roaring_bitmap_or, modifies x1.
+     */
     public func formUnion(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_or_inplace(self.ptr, x.ptr)
 
     }
     /**
-    * Inplace version of roaring_bitmap_or, modifies x1.
-    */
-    public static func |=(left: RoaringBitmap, right: RoaringBitmap){
+     * Inplace version of roaring_bitmap_or, modifies x1.
+     */
+    public static func |=(left: RoaringBitmap, right: RoaringBitmap) {
         left.formUnion(right)
     }
 
     /**
-    * Compute the union of 'number' bitmaps. See also roaring_bitmap_or_many_heap.
-    * Caller is responsible for freeing the
-    * result.
-    */
+     * Compute the union of 'number' bitmaps. See also roaring_bitmap_or_many_heap.
+     * Caller is responsible for freeing the
+     * result.
+     */
     public func unionMany(_ xs: [RoaringBitmap]) -> RoaringBitmap {
-        let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
+        let ptr = UnsafeMutablePointer<UnsafePointerroaring_bitmap_t?>>.allocate(capacity: xs.count + 1)
         ptr[0] = UnsafePointer<roaring_bitmap_t>(self.ptr)
         for (index, bitmap) in xs.enumerated() {
             ptr[index + 1] = UnsafePointer<roaring_bitmap_t>(bitmap.ptr)
@@ -214,14 +213,14 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     /**
-    * Compute the union of 'number' bitmaps using a heap. This can
-    * sometimes be faster than roaring_bitmap_or_many which uses
-    * a naive algorithm. Caller is responsible for freeing the
-    * result.
-    *
-    */
+     * Compute the union of 'number' bitmaps using a heap. This can
+     * sometimes be faster than roaring_bitmap_or_many which uses
+     * a naive algorithm. Caller is responsible for freeing the
+     * result.
+     *
+     */
     public func unionManyHeap(_ xs: [RoaringBitmap]) -> RoaringBitmap {
-        let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
+        let ptr = UnsafeMutablePointer<UnsafePointerroaring_bitmap_t?>>.allocate(capacity: xs.count + 1)
         ptr[0] = UnsafePointer<roaring_bitmap_t>(self.ptr)
         for (index, bitmap) in xs.enumerated() {
             ptr[index + 1] = UnsafePointer<roaring_bitmap_t>(bitmap.ptr)
@@ -230,46 +229,46 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     /**
-    * Computes the symmetric difference (xor) between two bitmaps
-    * and returns new bitmap. The caller is responsible for memory management.
-    */
+     * Computes the symmetric difference (xor) between two bitmaps
+     * and returns new bitmap. The caller is responsible for memory management.
+     */
     public func symmetricDifference(_ x: RoaringBitmap) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_xor(self.ptr, x.ptr))
         return x2
 
     }
     /**
-    * Computes the symmetric difference (xor) between two bitmaps
-    * and returns new bitmap. The caller is responsible for memory management.
-    */
-    public static func ^(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap{
+     * Computes the symmetric difference (xor) between two bitmaps
+     * and returns new bitmap. The caller is responsible for memory management.
+     */
+    public static func ^(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap {
         return left.symmetricDifference(right)
     }
 
     /**
-    * Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
-    *
-    */
+     * Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
+     *
+     */
     public func formSymmetricDifference(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_xor_inplace(self.ptr, x.ptr)
 
     }
     /**
-    * Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
-    *
-    */
-    public static func ^=(left: RoaringBitmap, right: RoaringBitmap){
+     * Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
+     *
+     */
+    public static func ^=(left: RoaringBitmap, right: RoaringBitmap) {
         left.formSymmetricDifference(right)
     }
 
     /**
-    * Compute the xor of 'number' bitmaps.
-    * Caller is responsible for freeing the
-    * result.
-    *
-    */
+     * Compute the xor of 'number' bitmaps.
+     * Caller is responsible for freeing the
+     * result.
+     *
+     */
     public func symmetricDifferenceMany(_ xs: [RoaringBitmap]) -> RoaringBitmap {
-        let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
+        let ptr = UnsafeMutablePointer<UnsafePointerroaring_bitmap_t?>>.allocate(capacity: xs.count + 1)
         ptr[0] = UnsafePointer<roaring_bitmap_t>(self.ptr)
         for (index, bitmap) in xs.enumerated() {
             ptr[index + 1] = UnsafePointer<roaring_bitmap_t>(bitmap.ptr)
@@ -277,91 +276,90 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         return RoaringBitmap(ptr: croaring.roaring_bitmap_xor_many(xs.count + 1, ptr))
     }
 
-
     /**
-    * Computes the  difference (andnot) between two bitmaps
-    * and returns new bitmap. The caller is responsible for memory management.
-    */
+     * Computes the  difference (andnot) between two bitmaps
+     * and returns new bitmap. The caller is responsible for memory management.
+     */
     public func subtracting(_ x: RoaringBitmap) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_andnot(self.ptr, x.ptr))
         return x2
 
     }
     /**
-    * Computes the  difference (andnot) between two bitmaps
-    * and returns new bitmap. The caller is responsible for memory management.
-    */
-    public static func -(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap{
+     * Computes the  difference (andnot) between two bitmaps
+     * and returns new bitmap. The caller is responsible for memory management.
+     */
+    public static func -(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap {
         return left.subtracting(right)
     }
 
     /**
-    * Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
-    *
-    */
+     * Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
+     *
+     */
     public func subtract(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_andnot_inplace(self.ptr, x.ptr)
 
     }
     /**
-    * Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
-    *
-    */
-    public static func -=(left: RoaringBitmap, right: RoaringBitmap){
+     * Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
+     *
+     */
+    public static func -=(left: RoaringBitmap, right: RoaringBitmap) {
         left.subtract(right)
     }
 
     /**
-    * Return true if the two bitmaps contain the same elements.
-    */
+     * Return true if the two bitmaps contain the same elements.
+     */
     public func equals(_ x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_equals(self.ptr, x.ptr)
 
     }
     /**
-    * Return true if the two bitmaps contain the same elements.
-    */
-    public static func ==(left: RoaringBitmap, right: RoaringBitmap) -> Bool{
+     * Return true if the two bitmaps contain the same elements.
+     */
+    public static func ==(left: RoaringBitmap, right: RoaringBitmap) -> Bool {
         return left.equals(right)
     }
     /**
-    * Return true if the two bitmaps DO NOT contain the same elements.
-    */
+     * Return true if the two bitmaps DO NOT contain the same elements.
+     */
     public static func !=(left: RoaringBitmap, right: RoaringBitmap) -> Bool {
         return !(left == right)
     }
 
     /**
-    * Return true if all the elements of ra1 are also in ra2.
-    */
+     * Return true if all the elements of ra1 are also in ra2.
+     */
     public func isSubset(of x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_is_subset(self.ptr, x.ptr)
 
     }
 
     /**
-    * Return true if all the elements of ra1 are also in ra2 and ra2 is strictly
-    * greater
-    * than ra1.
-    */
+     * Return true if all the elements of ra1 are also in ra2 and ra2 is strictly
+     * greater
+     * than ra1.
+     */
     public func isStrictSubset(of x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_is_strict_subset(self.ptr, x.ptr)
 
     }
 
     /**
-    * (For expert users who seek high performance.)
-    *
-    * Computes the union between two bitmaps and returns new bitmap. The caller is
-    * responsible for memory management.
-    *
-    * The lazy version defers some computations such as the maintenance of the
-    * cardinality counts. Thus you need
-    * to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
-    * It is safe to repeatedly call roaring_bitmap_lazy_or_inplace on the result.
-    * The bitsetconversion conversion is a flag which determines
-    * whether container-container operations force a bitset conversion.
-    **/
+     * (For expert users who seek high performance.)
+     *
+     * Computes the union between two bitmaps and returns new bitmap. The caller is
+     * responsible for memory management.
+     *
+     * The lazy version defers some computations such as the maintenance of the
+     * cardinality counts. Thus you need
+     * to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
+     * It is safe to repeatedly call roaring_bitmap_lazy_or_inplace on the result.
+     * The bitsetconversion conversion is a flag which determines
+     * whether container-container operations force a bitset conversion.
+     **/
     public func lazyUnion(_ x: RoaringBitmap, bitsetconversion: Bool) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_or(self.ptr, x.ptr, bitsetconversion))
         return x2
@@ -369,39 +367,39 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     /**
-    * (For expert users who seek high performance.)
-    * Inplace version of roaring_bitmap_lazy_or, modifies x1
-    * The bitsetconversion conversion is a flag which determines
-    * whether container-container operations force a bitset conversion.
-    */
+     * (For expert users who seek high performance.)
+     * Inplace version of roaring_bitmap_lazy_or, modifies x1
+     * The bitsetconversion conversion is a flag which determines
+     * whether container-container operations force a bitset conversion.
+     */
     public func formLazyUnion(_ x: RoaringBitmap, bitsetconversion: Bool) {
         croaring.roaring_bitmap_lazy_or_inplace(self.ptr, x.ptr, bitsetconversion)
 
     }
 
     /**
-    * (For expert users who seek high performance.)
-    *
-    * Execute maintenance operations on a bitmap created from
-    * roaring_bitmap_lazy_or
-    * or modified with roaring_bitmap_lazy_or_inplace.
-    */
+     * (For expert users who seek high performance.)
+     *
+     * Execute maintenance operations on a bitmap created from
+     * roaring_bitmap_lazy_or
+     * or modified with roaring_bitmap_lazy_or_inplace.
+     */
     public func repairAfterLazy() {
         croaring.roaring_bitmap_repair_after_lazy(self.ptr)
 
     }
 
     /**
-    * Computes the symmetric difference between two bitmaps and returns new bitmap.
-    *The caller is
-    * responsible for memory management.
-    *
-    * The lazy version defers some computations such as the maintenance of the
-    * cardinality counts. Thus you need
-    * to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
-    * It is safe to repeatedly call roaring_bitmap_lazy_xor_inplace on the result.
-    *
-    */
+     * Computes the symmetric difference between two bitmaps and returns new bitmap.
+     *The caller is
+     * responsible for memory management.
+     *
+     * The lazy version defers some computations such as the maintenance of the
+     * cardinality counts. Thus you need
+     * to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
+     * It is safe to repeatedly call roaring_bitmap_lazy_xor_inplace on the result.
+     *
+     */
     public func lazySymmetricDifference(_ x: RoaringBitmap) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_xor(self.ptr, x.ptr))
         return x2
@@ -409,21 +407,21 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     /**
-    * (For expert users who seek high performance.)
-    * Inplace version of roaring_bitmap_lazy_xor, modifies x1. x1 != x2
-    *
-    */
+     * (For expert users who seek high performance.)
+     * Inplace version of roaring_bitmap_lazy_xor, modifies x1. x1 != x2
+     *
+     */
     public func formLazySymmetricDifference(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_lazy_xor_inplace(self.ptr, x.ptr)
 
     }
 
     /**
-    * compute the negation of the roaring bitmap within a specified
-    * interval: [range_start, range_end). The number of negated values is
-    * range_end - range_start.
-    * Areas outside the range are passed through unchanged.
-    */
+     * compute the negation of the roaring bitmap within a specified
+     * interval: [range_start, range_end). The number of negated values is
+     * range_end - range_start.
+     * Areas outside the range are passed through unchanged.
+     */
     public func flip(rangeStart: UInt64, rangeEnd: UInt64) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_flip(self.ptr, rangeStart, rangeEnd))
         return x2
@@ -431,11 +429,11 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     /**
-    * compute (in place) the negation of the roaring bitmap within a specified
-    * interval: [range_start, range_end). The number of negated values is
-    * range_end - range_start.
-    * Areas outside the range are passed through unchanged.
-    */
+     * compute (in place) the negation of the roaring bitmap within a specified
+     * interval: [range_start, range_end). The number of negated values is
+     * range_end - range_start.
+     * Areas outside the range are passed through unchanged.
+     */
     public func flipInplace(rangeStart: UInt64, rangeEnd: UInt64) {
         croaring.roaring_bitmap_flip_inplace(self.ptr, rangeStart, rangeEnd)
     }
@@ -444,75 +442,72 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /////////////////////////////////////////////////////////////////////////////
     /////////////////////////////////////////////////////////////////////////////
 
-
     /**
-    * Copies a  bitmap. This does memory allocation. The caller is responsible for
-    * memory management.
-    *
-    */
+     * Copies a  bitmap. This does memory allocation. The caller is responsible for
+     * memory management.
+     *
+     */
     public func copy() -> RoaringBitmap {
         let cpy = RoaringBitmap(ptr: croaring.roaring_bitmap_copy(self.ptr))
         return cpy
     }
 
     /**
-    * Copies a  bitmap from src to dest. It is assumed that the pointer dest
-    * is to an already allocated bitmap. The content of the dest bitmap is
-    * freed/deleted.
-    *
-    * It might be preferable and simpler to call roaring_bitmap_copy except
-    * that roaring_bitmap_overwrite can save on memory allocations.
-    *
-    */
+     * Copies a  bitmap from src to dest. It is assumed that the pointer dest
+     * is to an already allocated bitmap. The content of the dest bitmap is
+     * freed/deleted.
+     *
+     * It might be preferable and simpler to call roaring_bitmap_copy except
+     * that roaring_bitmap_overwrite can save on memory allocations.
+     *
+     */
     // func overwrite(dest: RoaringBitmap) -> Bool {
     //     return croaring.roaring_bitmap_overwrite(dest.ptr, self.ptr)
     // }
 
     /**
-    * Add value x
-    *
-    */
-    public func add(_ value:UInt32) {
+     * Add value x
+     *
+     */
+    public func add(_ value: UInt32) {
         croaring.roaring_bitmap_add(self.ptr, value)
     }
 
     /**
-    * Add value n_args from pointer vals, faster than repeatedly calling
-    * roaring_bitmap_add
-    *
-    */
+     * Add value n_args from pointer vals, faster than repeatedly calling
+     * roaring_bitmap_add
+     *
+     */
     public func addMany(values: [UInt32]) {
         croaring.roaring_bitmap_add_many(self.ptr, values.count, values)
     }
 
     /**
-    * Add value x
-    * Returns true if a new value was added, false if the value was already existing.
-    */
-    public func addCheck(_ value:UInt32) -> Bool {
+     * Add value x
+     * Returns true if a new value was added, false if the value was already existing.
+     */
+    public func addCheck(_ value: UInt32) -> Bool {
         return croaring.roaring_bitmap_add_checked(self.ptr, value)
     }
 
     /**
-    * Add all values in range [min, max]
-    */
+     * Add all values in range [min, max]
+     */
     public func addRangeClosed(min: UInt32, max: UInt32) {
         croaring.roaring_bitmap_add_range_closed(self.ptr, min, max)
     }
 
-
     /**
-    * Add all values in range [min, max)
-    */
+     * Add all values in range [min, max)
+     */
     public func addRange(min: UInt64, max: UInt64) {
         croaring.roaring_bitmap_add_range(self.ptr, min, max)
     }
 
-
     /**
-    * Remove value x
-    */
-    public func remove(_ value:UInt32) {
+     * Remove value x
+     */
+    public func remove(_ value: UInt32) {
         croaring.roaring_bitmap_remove(self.ptr, value)
     }
 
@@ -533,83 +528,82 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     // }
 
     /**
-    * Remove value x
-    * Returns true if a new value was removed, false if the value was not existing.
-    */
-    public func removeCheck(_ value:UInt32) -> Bool {
+     * Remove value x
+     * Returns true if a new value was removed, false if the value was not existing.
+     */
+    public func removeCheck(_ value: UInt32) -> Bool {
         return croaring.roaring_bitmap_remove_checked(self.ptr, value)
     }
 
     /**
-    * Frees the memory.
-    */
+     * Frees the memory.
+     */
     private func free() {
         croaring.roaring_bitmap_free(self.ptr)
     }
 
     /**
-    * Empties the bitmap.
-    */
+     * Empties the bitmap.
+     */
     public func clear() {
         croaring.roaring_bitmap_clear(self.ptr)
     }
 
     /**
-    * Get the cardinality of the bitmap (number of elements).
-    */
+     * Get the cardinality of the bitmap (number of elements).
+     */
     public var count: UInt64 {
         return croaring.roaring_bitmap_get_cardinality(self.ptr)
     }
 
     /**
-    * Check if value x is present
-    */
+     * Check if value x is present
+     */
     public func contains(_ value: UInt32) -> Bool {
         return croaring.roaring_bitmap_contains(self.ptr, value)
     }
 
     /**
-    * Check whether a range of values from range_start (included) to range_end (excluded) is present
-    */
+     * Check whether a range of values from range_start (included) to range_end (excluded) is present
+     */
     public func containsRange(start: UInt64, end: UInt64) -> Bool {
         return croaring.roaring_bitmap_contains_range(self.ptr, start, end)
     }
     /**
-    * Check whether the bitmap is empty
-    */
+     * Check whether the bitmap is empty
+     */
     public var isEmpty: Bool {
         return croaring.roaring_bitmap_is_empty(self.ptr)
     }
 
     /**
-    * Print the content of the bitmap.
-    */
+     * Print the content of the bitmap.
+     */
     public func print() {
         croaring.roaring_bitmap_printf(self.ptr)
     }
 
     /**
-    * Describe the inner structure of the bitmap.
-    */
+     * Describe the inner structure of the bitmap.
+     */
     public func describe() {
         croaring.roaring_bitmap_printf_describe(self.ptr)
     }
 
     /**
-    * Convert the bitmap to an array. Write the output to "ans",
-    * caller is responsible to ensure that there is enough memory
-    * allocated
-    * (e.g., ans = malloc(roaring_bitmap_get_cardinality(mybitmap)
-    *   * sizeof(uint32_t))
-    */
+     * Convert the bitmap to an array. Write the output to "ans",
+     * caller is responsible to ensure that there is enough memory
+     * allocated
+     * (e.g., ans = malloc(roaring_bitmap_get_cardinality(mybitmap)
+     *   * sizeof(uint32_t))
+     */
     public func toArray() -> [UInt32] {
         let count = (Int(self.count) * MemoryLayout<UInt32>.size)/4
         var array = [UInt32](repeating: 0, count: count)
-        //let arrayPtr: UnsafeMutablePointer = UnsafeMutablePointer(mutating: array)
+        // let arrayPtr: UnsafeMutablePointer = UnsafeMutablePointer(mutating: array)
         croaring.roaring_bitmap_to_uint32_array(self.ptr, &array)
         return array
     }
-
 
     // /**
     // * Convert the bitmap to an array from "offset" by "limit". Write the output to "ans".
@@ -627,132 +621,129 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     // }
 
     /**
-    *  Remove run-length encoding even when it is more space efficient
-    *  return whether a change was applied
-    */
+     *  Remove run-length encoding even when it is more space efficient
+     *  return whether a change was applied
+     */
 
     public func removeRunCompression() -> Bool {
         return croaring.roaring_bitmap_remove_run_compression(self.ptr)
     }
 
-
     /** convert array and bitmap containers to run containers when it is more
-    * efficient;
-    * also convert from run containers when more space efficient.  Returns
-    * true if the result has at least one run container.
-    * Additional savings might be possible by calling shrinkToFit().
-    */
+     * efficient;
+     * also convert from run containers when more space efficient.  Returns
+     * true if the result has at least one run container.
+     * Additional savings might be possible by calling shrinkToFit().
+     */
     public func runOptimize() -> Bool {
         return croaring.roaring_bitmap_run_optimize(self.ptr)
     }
 
     /**
-    * If needed, reallocate memory to shrink the memory usage. Returns
-    * the number of bytes saved.
-    */
+     * If needed, reallocate memory to shrink the memory usage. Returns
+     * the number of bytes saved.
+     */
     public func shrink() -> size_t {
         return croaring.roaring_bitmap_shrink_to_fit(self.ptr)
     }
 
     /**
-    * write the bitmap to an output pointer, this output buffer should refer to
-    * at least roaring_bitmap_size_in_bytes(ra) allocated bytes.
-    *
-    * see roaring_bitmap_portable_serialize if you want a format that's compatible
-    * with Java and Go implementations
-    *
-    * this format has the benefit of being sometimes more space efficient than
-    * roaring_bitmap_portable_serialize
-    * e.g., when the data is sparse.
-    *
-    * Returns how many bytes were written which should be
-    * roaring_bitmap_size_in_bytes(ra).
-    */
+     * write the bitmap to an output pointer, this output buffer should refer to
+     * at least roaring_bitmap_size_in_bytes(ra) allocated bytes.
+     *
+     * see roaring_bitmap_portable_serialize if you want a format that's compatible
+     * with Java and Go implementations
+     *
+     * this format has the benefit of being sometimes more space efficient than
+     * roaring_bitmap_portable_serialize
+     * e.g., when the data is sparse.
+     *
+     * Returns how many bytes were written which should be
+     * roaring_bitmap_size_in_bytes(ra).
+     */
     public func serialize(buffer: inout [Int8]) -> size_t {
         return croaring.roaring_bitmap_serialize(self.ptr, &buffer)
     }
 
     /**  use with roaring_bitmap_serialize
-    * see roaring_bitmap_portable_deserialize if you want a format that's
-    * compatible with Java and Go implementations
-    */
+     * see roaring_bitmap_portable_deserialize if you want a format that's
+     * compatible with Java and Go implementations
+     */
     public static func deserialize(buffer: [Int8]) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_deserialize(buffer)!)
     }
 
     /**
-    * How many bytes are required to serialize this bitmap (NOT compatible
-    * with Java and Go versions)
-    */
+     * How many bytes are required to serialize this bitmap (NOT compatible
+     * with Java and Go versions)
+     */
     public func sizeInBytes() -> size_t {
         return croaring.roaring_bitmap_size_in_bytes(self.ptr)
     }
 
     /**
-    * read a bitmap from a serialized version. This is meant to be compatible with
-    * the Java and Go versions. See format specification at
-    * https://github.com/RoaringBitmap/RoaringFormatSpec
-    * In case of failure, a null pointer is returned.
-    * This function is unsafe in the sense that if there is no valid serialized
-    * bitmap at the pointer, then many bytes could be read, possibly causing a buffer
-    * overflow. For a safer approach,
-    * call roaring_bitmap_portable_deserialize_safe.
-    */
+     * read a bitmap from a serialized version. This is meant to be compatible with
+     * the Java and Go versions. See format specification at
+     * https://github.com/RoaringBitmap/RoaringFormatSpec
+     * In case of failure, a null pointer is returned.
+     * This function is unsafe in the sense that if there is no valid serialized
+     * bitmap at the pointer, then many bytes could be read, possibly causing a buffer
+     * overflow. For a safer approach,
+     * call roaring_bitmap_portable_deserialize_safe.
+     */
     public static func portableDeserialize(buffer: [Int8]) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_portable_deserialize(buffer)!)
     }
 
     /**
-    * read a bitmap from a serialized version in a safe manner (reading up to maxbytes).
-    * This is meant to be compatible with
-    * the Java and Go versions. See format specification at
-    * https://github.com/RoaringBitmap/RoaringFormatSpec
-    * In case of failure, a null pointer is returned.
-    */
+     * read a bitmap from a serialized version in a safe manner (reading up to maxbytes).
+     * This is meant to be compatible with
+     * the Java and Go versions. See format specification at
+     * https://github.com/RoaringBitmap/RoaringFormatSpec
+     * In case of failure, a null pointer is returned.
+     */
     public static func portableDeserializeSafe(buffer: [Int8], maxbytes: size_t) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_portable_deserialize_safe(buffer, maxbytes)!)
     }
 
     /**
-    * Check how many bytes would be read (up to maxbytes) at this pointer if there
-    * is a bitmap, returns zero if there is no valid bitmap.
-    * This is meant to be compatible with
-    * the Java and Go versions. See format specification at
-    * https://github.com/RoaringBitmap/RoaringFormatSpec
-    */
+     * Check how many bytes would be read (up to maxbytes) at this pointer if there
+     * is a bitmap, returns zero if there is no valid bitmap.
+     * This is meant to be compatible with
+     * the Java and Go versions. See format specification at
+     * https://github.com/RoaringBitmap/RoaringFormatSpec
+     */
     public static func portableDeserializeSize(buffer: [Int8], maxbytes: size_t) -> size_t {
         return croaring.roaring_bitmap_portable_deserialize_size(buffer, maxbytes)
     }
 
-
     /**
-    * How many bytes are required to serialize this bitmap (meant to be compatible
-    * with Java and Go versions).  See format specification at
-    * https://github.com/RoaringBitmap/RoaringFormatSpec
-    */
+     * How many bytes are required to serialize this bitmap (meant to be compatible
+     * with Java and Go versions).  See format specification at
+     * https://github.com/RoaringBitmap/RoaringFormatSpec
+     */
     public func portableSizeInBytes() -> size_t {
         return croaring.roaring_bitmap_portable_size_in_bytes(self.ptr)
     }
 
     /**
-    * write a bitmap to a char buffer.  The output buffer should refer to at least
-    *  roaring_bitmap_portable_size_in_bytes(ra) bytes of allocated memory.
-    * This is meant to be compatible with
-    * the
-    * Java and Go versions. Returns how many bytes were written which should be
-    * roaring_bitmap_portable_size_in_bytes(ra).  See format specification at
-    * https://github.com/RoaringBitmap/RoaringFormatSpec
-    */
+     * write a bitmap to a char buffer.  The output buffer should refer to at least
+     *  roaring_bitmap_portable_size_in_bytes(ra) bytes of allocated memory.
+     * This is meant to be compatible with
+     * the
+     * Java and Go versions. Returns how many bytes were written which should be
+     * roaring_bitmap_portable_size_in_bytes(ra).  See format specification at
+     * https://github.com/RoaringBitmap/RoaringFormatSpec
+     */
     public func portableSerialize(buffer: inout [Int8]) -> size_t {
         return croaring.roaring_bitmap_portable_serialize(self.ptr, &buffer)
     }
 
-
     /**
-    * If the size of the roaring bitmap is strictly greater than rank, then this
-    function returns true and set the value to the the given rank.
-    Otherwise, it returns false.
-    */
+     * If the size of the roaring bitmap is strictly greater than rank, then this
+     function returns true and set the value to the the given rank.
+     Otherwise, it returns false.
+     */
     public func select(rank: UInt32, value: UInt32) -> Bool {
         var cpy = value
         return croaring.roaring_bitmap_select(self.ptr, rank, &cpy)
@@ -760,37 +751,37 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     /**
-    * roaring_bitmap_rank returns the number of integers that are smaller or equal
-    * to x.
-    */
+     * roaring_bitmap_rank returns the number of integers that are smaller or equal
+     * to x.
+     */
     public func rank(value: UInt32) -> UInt64 {
         return croaring.roaring_bitmap_rank(self.ptr, value)
 
     }
 
     /**
-    * roaring_bitmap_smallest returns the smallest value in the set.
-    * Returns UINT32_MAX if the set is empty.
-    */
+     * roaring_bitmap_smallest returns the smallest value in the set.
+     * Returns UINT32_MAX if the set is empty.
+     */
     public func min() -> UInt32 {
         return croaring.roaring_bitmap_minimum(self.ptr)
 
     }
 
     /**
-    * roaring_bitmap_smallest returns the greatest value in the set.
-    * Returns 0 if the set is empty.
-    */
+     * roaring_bitmap_smallest returns the greatest value in the set.
+     * Returns 0 if the set is empty.
+     */
     public func max() -> UInt32 {
         return croaring.roaring_bitmap_maximum(self.ptr)
 
     }
 
     /**
-    *  (For advanced users.)
-    * Collect statistics about the bitmap, see RoaringStatistics.swift for
-    * a description of RoaringStatistics
-    */
+     *  (For advanced users.)
+     * Collect statistics about the bitmap, see RoaringStatistics.swift for
+     * a description of RoaringStatistics
+     */
 
     public func statistics() -> RoaringStatistics {
         var stats = RoaringStatistics()
@@ -799,15 +790,15 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     /**
-    * Creates a RoaringBitmapIterator.
-    */
+     * Creates a RoaringBitmapIterator.
+     */
     public func makeIterator() -> RoaringBitmapIterator {
         return RoaringBitmapIterator(ptr: self.ptr)
     }
 
     /**
-    * code used to iterate through values in a roaring bitmap
-    */
+     * code used to iterate through values in a roaring bitmap
+     */
     public struct RoaringBitmapIterator: IteratorProtocol {
         private var i: UnsafeMutablePointer<roaring_uint32_iterator_t>
 
@@ -816,7 +807,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         }
 
         mutating public func next() -> UInt32? {
-            if(i.pointee.has_value){
+            if i.pointee.has_value {
                 let val = i.pointee.current_value
                 croaring.roaring_advance_uint32_iterator(self.i)
                 return val
@@ -828,27 +819,27 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
 
     /* returns a string representation of the bitset */
     public var description: String {
-      var ret = prefix(100).map { $0.description }.joined(separator: ", ")
-      if self.count >= 100 {
-        ret.append(", ...")
-      }
-      return "{\(ret)}"
+        var ret = prefix(100).map { $0.description }.joined(separator: ", ")
+        if self.count >= 100 {
+            ret.append(", ...")
+        }
+        return "{\(ret)}"
     }
 
     /* hash value for the bitset, this is expensive and should be buffered
-    for performance */
+     for performance */
     public var hashValue: Int {
-      let b: UInt32 = 31
-      var hash: UInt32 = 0
-      for i in self {
-        hash = hash &* b &+ i
-      }
-      return Int(truncatingIfNeeded:hash)
+        let b: UInt32 = 31
+        var hash: UInt32 = 0
+        for i in self {
+            hash = hash &* b &+ i
+        }
+        return Int(truncatingIfNeeded: hash)
     }
 
     public func hash(into hasher: inout Hasher) {
-      for i in self {
-        i.hash(into: &hasher)
-      }
+        for i in self {
+            i.hash(into: &hasher)
+        }
     }
 }

--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -191,15 +191,15 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      * Caller is responsible for freeing the
      * result.
      */
+
     public func unionMany(_ xs: [RoaringBitmap]) -> RoaringBitmap {
-        let ptr = UnsafeMutablePointer<UnsafePointerroaring_bitmap_t?>>.allocate(capacity: xs.count + 1)
+        let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
         ptr[0] = UnsafePointer<roaring_bitmap_t>(self.ptr)
         for (index, bitmap) in xs.enumerated() {
             ptr[index + 1] = UnsafePointer<roaring_bitmap_t>(bitmap.ptr)
         }
         return RoaringBitmap(ptr: croaring.roaring_bitmap_or_many(xs.count + 1, ptr))
     }
-
     /**
      * Compute the union of 'number' bitmaps using a heap. This can
      * sometimes be faster than roaring_bitmap_or_many which uses
@@ -208,7 +208,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      *
      */
     public func unionManyHeap(_ xs: [RoaringBitmap]) -> RoaringBitmap {
-        let ptr = UnsafeMutablePointer<UnsafePointerroaring_bitmap_t?>>.allocate(capacity: xs.count + 1)
+        let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
         ptr[0] = UnsafePointer<roaring_bitmap_t>(self.ptr)
         for (index, bitmap) in xs.enumerated() {
             ptr[index + 1] = UnsafePointer<roaring_bitmap_t>(bitmap.ptr)
@@ -253,7 +253,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      *
      */
     public func symmetricDifferenceMany(_ xs: [RoaringBitmap]) -> RoaringBitmap {
-        let ptr = UnsafeMutablePointer<UnsafePointerroaring_bitmap_t?>>.allocate(capacity: xs.count + 1)
+        let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
         ptr[0] = UnsafePointer<roaring_bitmap_t>(self.ptr)
         for (index, bitmap) in xs.enumerated() {
             ptr[index + 1] = UnsafePointer<roaring_bitmap_t>(bitmap.ptr)

--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -1,13 +1,13 @@
 import croaring
 
-/**
- * This class contains different values about a given RoaringBitmap
- */
+///
+/// This class contains different values about a given RoaringBitmap
+///
 public typealias RoaringStatistics = roaring_statistics_t
 
-/**
- * Swift wrapper for CRoaring (a C/C++ implementation at https://github.com/RoaringBitmap/CRoaring)
- */
+///
+/// Swift wrapper for CRoaring (a C/C++ implementation at https://github.com/RoaringBitmap/CRoaring)
+///
 public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
                             Hashable, ExpressibleByArrayLiteral {
     var ptr: UnsafeMutablePointer<roaring_bitmap_t>
@@ -72,7 +72,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /// caller is
     /// responsible for memory management.
     ///
-    ///
     public func intersection(_ x: RoaringBitmap) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_and(self.ptr, x.ptr))
     }
@@ -80,7 +79,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /// Computes the intersection between two bitmaps and returns new bitmap. The
     /// caller is
     /// responsible for memory management.
-    ///
     ///
     public static func &(left: RoaringBitmap, right: RoaringBitmap) -> RoaringBitmap {
         return left.intersection(right)
@@ -102,14 +100,12 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     ///
     /// Computes the size of the intersection between two bitmaps.
     ///
-    ///
     public func intersectionCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_and_cardinality(self.ptr, x.ptr)
     }
 
     ///
     /// Check whether two bitmaps intersect.
-    ///
     ///
     public func intersect(_ x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_intersect(self.ptr, x.ptr)
@@ -122,7 +118,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     ///
     /// The Jaccard index is undefined if both bitmaps are empty.
     ///
-    ///
     public func jaccardIndex(_ x: RoaringBitmap) -> Double {
         return croaring.roaring_bitmap_jaccard_index(self.ptr, x.ptr)
     }
@@ -130,14 +125,12 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     ///
     /// Computes the size of the union between two bitmaps.
     ///
-    ///
     public func unionCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_or_cardinality(self.ptr, x.ptr)
     }
 
     ///
     /// Computes the size of the difference (andnot) between two bitmaps.
-    ///
     ///
     public func subtractingCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_andnot_cardinality(self.ptr, x.ptr)
@@ -152,7 +145,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
 
     ///
     /// Computes the size of the symmetric difference (andnot) between two bitmaps.
-    ///
     ///
     public func symmetricDifferenceCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_xor_cardinality(self.ptr, x.ptr)
@@ -180,18 +172,16 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         croaring.roaring_bitmap_or_inplace(self.ptr, x.ptr)
     }
     ///
-    /// Inplace version of roaring_bitmap_or, modifies x1.
+    /// Inplace version of `roaring_bitmap_or, modifies` x1.
     ///
     public static func |=(left: RoaringBitmap, right: RoaringBitmap) {
         left.formUnion(right)
     }
 
     ///
-    /// Compute the union of 'number' bitmaps. See also roaring_bitmap_or_many_heap.
-    /// Caller is responsible for freeing the
-    /// result.
+    /// Compute the union of 'number' bitmaps. See also `roaring_bitmap_or_many_heap`.
+    /// Caller is responsible for freeing the result.
     ///
-
     public func unionMany(_ xs: [RoaringBitmap]) -> RoaringBitmap {
         let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
         ptr[0] = UnsafePointer<roaring_bitmap_t>(self.ptr)
@@ -202,10 +192,9 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
     ///
     /// Compute the union of 'number' bitmaps using a heap. This can
-    /// sometimes be faster than roaring_bitmap_or_many which uses
+    /// sometimes be faster than `roaring_bitmap_or_many` which uses
     /// a naive algorithm. Caller is responsible for freeing the
     /// result.
-    ///
     ///
     public func unionManyHeap(_ xs: [RoaringBitmap]) -> RoaringBitmap {
         let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
@@ -234,13 +223,11 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     ///
     /// Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
     ///
-    ///
     public func formSymmetricDifference(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_xor_inplace(self.ptr, x.ptr)
     }
     ///
     /// Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
-    ///
     ///
     public static func ^=(left: RoaringBitmap, right: RoaringBitmap) {
         left.formSymmetricDifference(right)
@@ -250,7 +237,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /// Compute the xor of 'number' bitmaps.
     /// Caller is responsible for freeing the
     /// result.
-    ///
     ///
     public func symmetricDifferenceMany(_ xs: [RoaringBitmap]) -> RoaringBitmap {
         let ptr = UnsafeMutablePointer<Optional<UnsafePointer<roaring_bitmap_t>>>.allocate(capacity: xs.count + 1)
@@ -279,13 +265,11 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     ///
     /// Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
     ///
-    ///
     public func subtract(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_andnot_inplace(self.ptr, x.ptr)
     }
     ///
     /// Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
-    ///
     ///
     public static func -=(left: RoaringBitmap, right: RoaringBitmap) {
         left.subtract(right)
@@ -365,7 +349,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /// to call roaring_bitmap_repair_after_lazy after executing "lazy" computations.
     /// It is safe to repeatedly call roaring_bitmap_lazy_xor_inplace on the result.
     ///
-    ///
     public func lazySymmetricDifference(_ x: RoaringBitmap) -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_xor(self.ptr, x.ptr))
     }
@@ -373,7 +356,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     ///
     /// (For expert users who seek high performance.)
     /// Inplace version of roaring_bitmap_lazy_xor, modifies x1. x1 != x2
-    ///
     ///
     public func formLazySymmetricDifference(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_lazy_xor_inplace(self.ptr, x.ptr)
@@ -407,7 +389,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /// Copies a  bitmap. This does memory allocation. The caller is responsible for
     /// memory management.
     ///
-    ///
     public func copy() -> RoaringBitmap {
         return RoaringBitmap(ptr: croaring.roaring_bitmap_copy(self.ptr))
     }
@@ -427,7 +408,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
 
     ///
     /// Add value x
-    ///
     ///
     public func add(_ value: UInt32) {
         croaring.roaring_bitmap_add(self.ptr, value)
@@ -625,6 +605,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         return croaring.roaring_bitmap_serialize(self.ptr, &buffer)
     }
 
+    ///
     /// use with roaring_bitmap_serialize
     /// see roaring_bitmap_portable_deserialize if you want a format that's
     /// compatible with Java and Go implementations
@@ -734,7 +715,7 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     ///
-    ///  (For advanced users.)
+    /// (For advanced users.)
     /// Collect statistics about the bitmap, see RoaringStatistics.swift for
     /// a description of RoaringStatistics
     ///
@@ -772,7 +753,9 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         }
     }
 
-    /* returns a string representation of the bitset */
+    ///
+    /// returns a string representation of the bitset
+    ///
     public var description: String {
         var ret = prefix(100).map { $0.description }.joined(separator: ", ")
         if self.count >= 100 {
@@ -781,8 +764,10 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         return "{\(ret)}"
     }
 
-    /* hash value for the bitset, this is expensive and should be buffered
-     for performance */
+    ///
+    /// hash value for the bitset, this is expensive and should be buffered
+    /// for performance
+    ///
     public func hash(into hasher: inout Hasher) {
         let b: UInt32 = 31
         var hash: UInt32 = 0

--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -92,7 +92,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func formIntersection(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_and_inplace(self.ptr, x.ptr)
-
     }
     /**
      * Inplace version modifies x1, x1 == x2 is allowed
@@ -107,7 +106,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func intersectionCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_and_cardinality(self.ptr, x.ptr)
-
     }
 
     /**
@@ -116,7 +114,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func intersect(_ x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_intersect(self.ptr, x.ptr)
-
     }
 
     /**
@@ -129,7 +126,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func jaccardIndex(_ x: RoaringBitmap) -> Double {
         return croaring.roaring_bitmap_jaccard_index(self.ptr, x.ptr)
-
     }
 
     /**
@@ -138,7 +134,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func unionCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_or_cardinality(self.ptr, x.ptr)
-
     }
 
     /**
@@ -147,7 +142,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func subtractingCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_andnot_cardinality(self.ptr, x.ptr)
-
     }
 
     /**
@@ -163,7 +157,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func symmetricDifferenceCount(_ x: RoaringBitmap) -> UInt64 {
         return croaring.roaring_bitmap_xor_cardinality(self.ptr, x.ptr)
-
     }
 
     /**
@@ -173,7 +166,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     public func union(_ x: RoaringBitmap) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_or(self.ptr, x.ptr))
         return x2
-
     }
     /**
      * Computes the union between two bitmaps and returns new bitmap. The caller is
@@ -188,7 +180,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func formUnion(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_or_inplace(self.ptr, x.ptr)
-
     }
     /**
      * Inplace version of roaring_bitmap_or, modifies x1.
@@ -209,7 +200,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
             ptr[index + 1] = UnsafePointer<roaring_bitmap_t>(bitmap.ptr)
         }
         return RoaringBitmap(ptr: croaring.roaring_bitmap_or_many(xs.count + 1, ptr))
-
     }
 
     /**
@@ -235,7 +225,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     public func symmetricDifference(_ x: RoaringBitmap) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_xor(self.ptr, x.ptr))
         return x2
-
     }
     /**
      * Computes the symmetric difference (xor) between two bitmaps
@@ -251,7 +240,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func formSymmetricDifference(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_xor_inplace(self.ptr, x.ptr)
-
     }
     /**
      * Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
@@ -283,7 +271,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     public func subtracting(_ x: RoaringBitmap) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_andnot(self.ptr, x.ptr))
         return x2
-
     }
     /**
      * Computes the  difference (andnot) between two bitmaps
@@ -299,7 +286,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func subtract(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_andnot_inplace(self.ptr, x.ptr)
-
     }
     /**
      * Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
@@ -314,7 +300,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func equals(_ x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_equals(self.ptr, x.ptr)
-
     }
     /**
      * Return true if the two bitmaps contain the same elements.
@@ -334,7 +319,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func isSubset(of x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_is_subset(self.ptr, x.ptr)
-
     }
 
     /**
@@ -344,7 +328,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func isStrictSubset(of x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_is_strict_subset(self.ptr, x.ptr)
-
     }
 
     /**
@@ -363,7 +346,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     public func lazyUnion(_ x: RoaringBitmap, bitsetconversion: Bool) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_or(self.ptr, x.ptr, bitsetconversion))
         return x2
-
     }
 
     /**
@@ -374,7 +356,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func formLazyUnion(_ x: RoaringBitmap, bitsetconversion: Bool) {
         croaring.roaring_bitmap_lazy_or_inplace(self.ptr, x.ptr, bitsetconversion)
-
     }
 
     /**
@@ -386,7 +367,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func repairAfterLazy() {
         croaring.roaring_bitmap_repair_after_lazy(self.ptr)
-
     }
 
     /**
@@ -403,7 +383,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     public func lazySymmetricDifference(_ x: RoaringBitmap) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_lazy_xor(self.ptr, x.ptr))
         return x2
-
     }
 
     /**
@@ -413,7 +392,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func formLazySymmetricDifference(_ x: RoaringBitmap) {
         croaring.roaring_bitmap_lazy_xor_inplace(self.ptr, x.ptr)
-
     }
 
     /**
@@ -425,7 +403,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     public func flip(rangeStart: UInt64, rangeEnd: UInt64) -> RoaringBitmap {
         let x2 = RoaringBitmap(ptr: croaring.roaring_bitmap_flip(self.ptr, rangeStart, rangeEnd))
         return x2
-
     }
 
     /**
@@ -747,7 +724,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     public func select(rank: UInt32, value: UInt32) -> Bool {
         var cpy = value
         return croaring.roaring_bitmap_select(self.ptr, rank, &cpy)
-
     }
 
     /**
@@ -756,7 +732,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func rank(value: UInt32) -> UInt64 {
         return croaring.roaring_bitmap_rank(self.ptr, value)
-
     }
 
     /**
@@ -765,7 +740,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func min() -> UInt32 {
         return croaring.roaring_bitmap_minimum(self.ptr)
-
     }
 
     /**
@@ -774,7 +748,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
      */
     public func max() -> UInt32 {
         return croaring.roaring_bitmap_maximum(self.ptr)
-
     }
 
     /**
@@ -814,7 +787,6 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
             }
             return nil
         }
-
     }
 
     /* returns a string representation of the bitset */

--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -294,20 +294,11 @@ public class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /**
      * Return true if the two bitmaps contain the same elements.
      */
-    public func equals(_ x: RoaringBitmap) -> Bool {
-        return croaring.roaring_bitmap_equals(self.ptr, x.ptr)
-    }
     /**
      * Return true if the two bitmaps contain the same elements.
      */
     public static func ==(left: RoaringBitmap, right: RoaringBitmap) -> Bool {
-        return left.equals(right)
-    }
-    /**
-     * Return true if the two bitmaps DO NOT contain the same elements.
-     */
-    public static func !=(left: RoaringBitmap, right: RoaringBitmap) -> Bool {
-        return !(left == right)
+        return croaring.roaring_bitmap_equals(left.ptr, right.ptr)
     }
 
     /**

--- a/Tests/swiftRoaringTests/XCTestManifests.swift
+++ b/Tests/swiftRoaringTests/XCTestManifests.swift
@@ -31,13 +31,13 @@ extension swiftRoaringTests {
         ("testStatistics", testStatistics),
         ("testSubset", testSubset),
         ("testToArray", testToArray),
-        ("testXor", testXor),
+        ("testXor", testXor)
     ]
 }
 
 public func __allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(swiftRoaringTests.__allTests__swiftRoaringTests),
+        testCase(swiftRoaringTests.__allTests__swiftRoaringTests)
     ]
 }
 #endif

--- a/Tests/swiftRoaringTests/swiftRoaringTests.swift
+++ b/Tests/swiftRoaringTests/swiftRoaringTests.swift
@@ -111,9 +111,8 @@ class swiftRoaringTests: XCTestCase {
 
     func testEquals() {
         let cpy = rbm.copy()
-        XCTAssertTrue(cpy.equals(rbm))
         XCTAssertTrue(cpy == rbm)
-        XCTAssertEqual(cpy != rbm, false)
+        XCTAssertFalse(cpy != rbm)
     }
 
     func testSubset() {
@@ -347,10 +346,6 @@ class swiftRoaringTests: XCTestCase {
     }
 
     func makeList(_ n: Int) -> [UInt32] {
-         #if os(Linux)
-            return (0..<n).map { _ in UInt32(Int.random(in: 0 ..< 1000)) }
-        #else
-            return (0..<n).map { _ in UInt32(arc4random_uniform(1000)+1) }
-        #endif
+        return (0..<n).map { _ in UInt32.random(in: 0 ..< 1000) }
     }
 }

--- a/Tests/swiftRoaringTests/swiftRoaringTests.swift
+++ b/Tests/swiftRoaringTests/swiftRoaringTests.swift
@@ -1,9 +1,8 @@
 import XCTest
 @testable import SwiftRoaring
 
-
 extension swiftRoaringTests {
-    static var allTests : [(String, (swiftRoaringTests) -> () throws -> Void)] {
+    static var allTests: [(String, (swiftRoaringTests) -> () throws -> Void)] {
         return [
             ("testAdd", testAdd),
             ("testRemove", testRemove),
@@ -28,9 +27,9 @@ extension swiftRoaringTests {
             ("testPortableSerialize", testPortableSerialize),
             ("testStatistics", testStatistics),
             ("testJaccardIndex", testJaccardIndex),
-            ("testDescription", testDescription), 
-            ("testHashValue", testHashValue),   
-            ("testBase64", testBase64),    
+            ("testDescription", testDescription),
+            ("testHashValue", testHashValue),
+            ("testBase64", testBase64)
 
         ]
     }
@@ -73,51 +72,51 @@ class swiftRoaringTests: XCTestCase {
         for i in rbm {
             XCTAssertEqual(rbm.contains(i), true)
             count -= 1
-            if(count < 0) {break}
+            if count < 0 {break}
         }
         XCTAssertEqual(count, 0)
     }
 
-    func testInitRange(){
-        let rbmRange = RoaringBitmap(min: 0,max: 1000,step: 50)
+    func testInitRange() {
+        let rbmRange = RoaringBitmap(min: 0, max: 1000, step: 50)
         for k in stride(from: 0, to: 1000, by: 50 ) {
             XCTAssertEqual(rbmRange.contains(UInt32(k)), true)
         }
     }
 
-    func testInitCapacity(){
+    func testInitCapacity() {
         let rbmCapacity = RoaringBitmap(capacity: 8)
         XCTAssertEqual(rbmCapacity.sizeInBytes(), 5)
     }
 
-    func testInitArray(){
-        let array = [0,1,2,4,5,6]
-        let rbmArray = RoaringBitmap(values: array.map{ UInt32($0) })
+    func testInitArray() {
+        let array = [0, 1, 2, 4, 5, 6]
+        let rbmArray = RoaringBitmap(values: array.map { UInt32($0) })
         for i in array {
             XCTAssertEqual(rbmArray.contains(UInt32(i)), true)
         }
-        let l: RoaringBitmap = [0,1,2,4,5,6]
+        let l: RoaringBitmap = [0, 1, 2, 4, 5, 6]
         for i in array {
             XCTAssertEqual(l.contains(UInt32(i)), true)
         }
     }
 
-    func testFlip(){
-        rbm.addRangeClosed(min:0, max:500)
-        let flip = rbm.flip(rangeStart: 0, rangeEnd:501)
+    func testFlip() {
+        rbm.addRangeClosed(min: 0, max: 500)
+        let flip = rbm.flip(rangeStart: 0, rangeEnd: 501)
         XCTAssertTrue(flip.isEmpty)
-        rbm.flipInplace(rangeStart: 0, rangeEnd:501)
+        rbm.flipInplace(rangeStart: 0, rangeEnd: 501)
         XCTAssertTrue(rbm.isEmpty)
     }
 
-    func testEquals(){
+    func testEquals() {
         let cpy = rbm.copy()
         XCTAssertTrue(cpy.equals(rbm))
         XCTAssertTrue(cpy == rbm)
         XCTAssertEqual(cpy != rbm, false)
     }
 
-    func testSubset(){
+    func testSubset() {
         let cpy = rbm.copy()
         XCTAssertTrue(rbm.isSubset(of: cpy))
         cpy.add(800)
@@ -125,22 +124,22 @@ class swiftRoaringTests: XCTestCase {
         cpy.remove(800)
     }
 
-    func testOptimisations(){
-        rbm.addRangeClosed(min:0, max:500)
+    func testOptimisations() {
+        rbm.addRangeClosed(min: 0, max: 500)
         XCTAssertTrue(rbm.sizeInBytes() > 0)
         XCTAssertTrue(rbm.shrink() >= 0)
         XCTAssertTrue(rbm.runOptimize())
         XCTAssertTrue(rbm.removeRunCompression())
     }
 
-    func testPrinting(){
+    func testPrinting() {
         let rbmap = RoaringBitmap()
         rbmap.add(1)
         rbmap.describe()
         rbmap.print()
     }
 
-    func testToArray(){
+    func testToArray() {
         rbm.add(35)
         var array = rbm.toArray()
         for i in rbm {
@@ -152,10 +151,10 @@ class swiftRoaringTests: XCTestCase {
         XCTAssertTrue(rbm.count == 1)
     }
 
-    func testAddingRemoving(){
-        rbm.addRangeClosed(min:0, max:500)
+    func testAddingRemoving() {
+        rbm.addRangeClosed(min: 0, max: 500)
         let cpy = rbm.copy()
-        _ = cpy.containsRange(start:0, end:501)
+        _ = cpy.containsRange(start: 0, end: 501)
         XCTAssertEqual(cpy.max(), 500)
         XCTAssertEqual(cpy.min(), 0)
         XCTAssertEqual(cpy.rank(value: 499), 500)
@@ -168,19 +167,19 @@ class swiftRoaringTests: XCTestCase {
         rbmap.removeRangeClosed(min: 0, max: 10)
         XCTAssertTrue(rbmap.count == 0)
         XCTAssertTrue(rbmap.addCheck(0))
-        rbmap.addMany(values: [1,2,3])
+        rbmap.addMany(values: [1, 2, 3])
         XCTAssertTrue(rbmap.count == 4)
         XCTAssertTrue(rbmap.removeCheck(3))
         XCTAssertTrue(rbmap.count == 3)
     }
 
-    func testSelect(){
-        rbm.addRangeClosed(min:0, max:500)
-        XCTAssertTrue(rbm.select(rank:5, value: 800))
-        XCTAssertEqual(rbm.rank(value:800), 501)
+    func testSelect() {
+        rbm.addRangeClosed(min: 0, max: 500)
+        XCTAssertTrue(rbm.select(rank: 5, value: 800))
+        XCTAssertEqual(rbm.rank(value: 800), 501)
     }
 
-    func testAnd(){
+    func testAnd() {
         let (rbm1, rbm2, swiftSet1, swiftSet2) = makeSets()
 
         let andRbm = rbm1 & rbm2
@@ -193,10 +192,10 @@ class swiftRoaringTests: XCTestCase {
         let andCardinality = rbm1.intersectionCount(rbm2)
         XCTAssertEqual(Int(andCardinality), andSwift.count)
 
-        XCTAssertEqual(rbm1.intersect(rbm2), andSwift.count > 0)   
+        XCTAssertEqual(rbm1.intersect(rbm2), andSwift.count > 0)
     }
 
-    func testOr(){
+    func testOr() {
         let (rbm1, rbm2, swiftSet1, swiftSet2) = makeSets()
 
         let andRbm = rbm1 | rbm2
@@ -207,13 +206,13 @@ class swiftRoaringTests: XCTestCase {
         XCTAssertEqual(Int(orCardinality), andSwift.count)
 
         let (rbm3, rbm4, swiftSet3, swiftSet4) = makeSets()
-        var orMany = rbm1.unionMany([rbm2,rbm3,rbm4])
+        var orMany = rbm1.unionMany([rbm2, rbm3, rbm4])
         var swiftOrMany = swiftSet1.union(swiftSet2)
         swiftOrMany = swiftOrMany.union(swiftSet3)
         swiftOrMany = swiftOrMany.union(swiftSet4)
         XCTAssertEqual(swiftOrMany, Set(orMany.toArray()))
 
-        orMany = rbm1.unionManyHeap([rbm2,rbm3,rbm4])
+        orMany = rbm1.unionManyHeap([rbm2, rbm3, rbm4])
         XCTAssertEqual(swiftOrMany, Set(orMany.toArray()))
 
         let lazy = rbm3.lazyUnion(rbm4, bitsetconversion: false)
@@ -226,7 +225,7 @@ class swiftRoaringTests: XCTestCase {
         XCTAssertEqual(andSwift, Set(rbm1.toArray()))
     }
 
-    func testXor(){
+    func testXor() {
         let (rbm1, rbm2, swiftSet1, swiftSet2) = makeSets()
 
         let andRbm = rbm1 ^ rbm2
@@ -237,7 +236,7 @@ class swiftRoaringTests: XCTestCase {
         XCTAssertEqual(Int(xorCardinality), andSwift.count)
 
         let (rbm3, rbm4, swiftSet3, swiftSet4) = makeSets()
-        let orMany = rbm1.symmetricDifferenceMany([rbm2,rbm3,rbm4])
+        let orMany = rbm1.symmetricDifferenceMany([rbm2, rbm3, rbm4])
         var swiftOrMany = swiftSet1.symmetricDifference(swiftSet2)
         swiftOrMany = swiftOrMany.symmetricDifference(swiftSet3)
         swiftOrMany = swiftOrMany.symmetricDifference(swiftSet4)
@@ -253,7 +252,7 @@ class swiftRoaringTests: XCTestCase {
         XCTAssertEqual(andSwift, Set(rbm1.toArray()))
     }
 
-    func testAndNot(){
+    func testAndNot() {
         let (rbm1, rbm2, swiftSet1, swiftSet2) = makeSets()
 
         let andRbm = rbm1 - rbm2
@@ -267,8 +266,8 @@ class swiftRoaringTests: XCTestCase {
         XCTAssertEqual(Int(andNotCardinality), andSwift.count)
     }
 
-    func testSerialize(){
-        rbm.addRangeClosed(min:0, max:500)
+    func testSerialize() {
+        rbm.addRangeClosed(min: 0, max: 500)
         let size = rbm.sizeInBytes()
         var buffer = [Int8](repeating: 0, count: size)
         XCTAssertEqual(rbm.serialize(buffer: &buffer), size)
@@ -277,8 +276,8 @@ class swiftRoaringTests: XCTestCase {
 
     }
 
-    func testPortableSerialize(){
-        rbm.addRangeClosed(min:0, max:500)
+    func testPortableSerialize() {
+        rbm.addRangeClosed(min: 0, max: 500)
         let size = rbm.portableSizeInBytes()
         var buffer = [Int8](repeating: 0, count: size)
         XCTAssertEqual(rbm.portableSerialize(buffer: &buffer), size)
@@ -289,15 +288,15 @@ class swiftRoaringTests: XCTestCase {
         XCTAssertTrue(deserializedSafeRbm == rbm)
     }
 
-    func testBase64(){
+    func testBase64() {
         let bitmap = RoaringBitmap()
-        for i in 0..<50 { 
+        for i in 0..<50 {
           // from https://github.com/RoaringBitmap/SwiftRoaring/issues/1
           let random = Int.random(in: 0...1)
           if random == 0 {
             bitmap.add(UInt32(i))
           }
-        } 
+        }
         let size = rbm.portableSizeInBytes()
         var buffer = [Int8](repeating: 0, count: size)
         XCTAssertEqual(rbm.portableSerialize(buffer: &buffer), size)
@@ -313,32 +312,30 @@ class swiftRoaringTests: XCTestCase {
         XCTAssertTrue(deserializedSafeRbm == rbm)
     }
 
-
-    func testStatistics(){
-        rbm.addRangeClosed(min:0, max:500)
+    func testStatistics() {
+        rbm.addRangeClosed(min: 0, max: 500)
         let stats = rbm.statistics()
         XCTAssertTrue(stats.max_value == 500)
         XCTAssertTrue(stats.min_value == 0)
         XCTAssertTrue(stats.cardinality == 501)
     }
 
-    func testJaccardIndex(){
-        rbm.addMany(values: [1,2,3])
-        let rbm2 = RoaringBitmap(values: [3,4,5])
+    func testJaccardIndex() {
+        rbm.addMany(values: [1, 2, 3])
+        let rbm2 = RoaringBitmap(values: [3, 4, 5])
         XCTAssertEqual(rbm.jaccardIndex(rbm2), 0.2)
     }
 
-    func testDescription(){
-        rbm.addRangeClosed(min:0, max:500)
+    func testDescription() {
+        rbm.addRangeClosed(min: 0, max: 500)
         print(rbm.description)
     }
 
-    func testHashValue(){
+    func testHashValue() {
         print(rbm.hashValue)
     }
 
-
-    func makeSets() -> (RoaringBitmap, RoaringBitmap, Set<UInt32>, Set<UInt32>){
+    func makeSets() -> (RoaringBitmap, RoaringBitmap, Set<UInt32>, Set<UInt32>) {
         let randList1 = makeList(100)
         let randList2 = makeList(100)
         let rbm1 = RoaringBitmap(values: randList1)
@@ -351,9 +348,9 @@ class swiftRoaringTests: XCTestCase {
 
     func makeList(_ n: Int) -> [UInt32] {
          #if os(Linux)
-            return (0..<n).map{ _ in UInt32(Int.random(in: 0 ..< 1000)) }
+            return (0..<n).map { _ in UInt32(Int.random(in: 0 ..< 1000)) }
         #else
-            return (0..<n).map{ _ in UInt32(arc4random_uniform(1000)+1) }
+            return (0..<n).map { _ in UInt32(arc4random_uniform(1000)+1) }
         #endif
     }
 }


### PR DESCRIPTION
In addition to that this fixed the problem with how Hashable conformance. `func hash(into: Hasher)` and `var hashValue` were producing different hashes. The `var hashValue` property is not necessary anymore. Also removed some unnecessary implementation related to Equatable.