### PR TITLE
Added methods first, dropFirst, last, dropLast and isDisjoint

### DIFF
--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -904,6 +904,32 @@ public final class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
         return croaring.roaring_bitmap_maximum(self.ptr)
     }
 
+    @inlinable @inline(__always)
+    public var first: UInt32? {
+        guard !self.isEmpty else { return nil }
+        return croaring.roaring_bitmap_minimum(self.ptr)
+    }
+
+    @inlinable @inline(__always)
+    public func dropFirst() -> UInt32? {
+        guard let first = self.first else { return nil }
+        self.remove(first)
+        return first
+    }
+
+    @inlinable @inline(__always)
+    public var last: UInt32? {
+        guard !self.isEmpty else { return nil }
+        return croaring.roaring_bitmap_maximum(self.ptr)
+    }
+
+    @inlinable @inline(__always)
+    public func dropLast() -> UInt32? {
+        guard let last = self.last else { return nil }
+        self.remove(last)
+        return last
+    }
+
     ///
     /// (For advanced users.)
     /// Collect statistics about the bitmap, see RoaringStatistics.swift for

--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -330,12 +330,19 @@ public final class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
 
     ///
     /// Return true if all the elements of ra1 are also in ra2 and ra2 is strictly
-    /// greater
-    /// than ra1.
+    /// greater than ra1.
     ///
     @inlinable @inline(__always)
     public func isStrictSubset(of x: RoaringBitmap) -> Bool {
         return croaring.roaring_bitmap_is_strict_subset(self.ptr, x.ptr)
+    }
+
+    ///
+    /// Return true if ra1 and ra2 have no elements in common.
+    ///
+    @inlinable @inline(__always)
+    public func isDisjoint(with other: RoaringBitmap) -> Bool {
+        return croaring.roaring_bitmap_and_cardinality(self.ptr, other.ptr) == 0
     }
 
     ///

--- a/Tests/swiftRoaringTests/swiftRoaringTests.swift
+++ b/Tests/swiftRoaringTests/swiftRoaringTests.swift
@@ -411,4 +411,14 @@ class swiftRoaringTests: XCTestCase {
         XCTAssert(b.last == nil)
         XCTAssert(b.isEmpty)
     }
+
+    func testIsDisjoint() {
+        let a: RoaringBitmap = [1,2,3,4,5]
+        let b: RoaringBitmap = [6,7,8,9,10]
+
+        let c: RoaringBitmap = [5,6,7,8]
+
+        XCTAssert(a.isDisjoint(with: b))
+        XCTAssert(!a.isDisjoint(with: c))
+    }
 }

--- a/Tests/swiftRoaringTests/swiftRoaringTests.swift
+++ b/Tests/swiftRoaringTests/swiftRoaringTests.swift
@@ -353,7 +353,7 @@ class swiftRoaringTests: XCTestCase {
         let enc = JSONEncoder()
         let dec = JSONDecoder()
 
-        var r = RoaringBitmap(min: 0, max: 100, step: 2)
+        let r = RoaringBitmap(min: 0, max: 100, step: 2)
 
         let a = try! enc.encode(r)
 
@@ -380,5 +380,35 @@ class swiftRoaringTests: XCTestCase {
 
     func makeList(_ n: Int) -> [UInt32] {
         return (0..<n).map { _ in UInt32.random(in: 0 ..< 1000) }
+    }
+
+
+    func testFirst() {
+        let a: RoaringBitmap = []
+        XCTAssert(a.first == nil)
+
+        let b: RoaringBitmap = [1, 2, 3]
+
+        XCTAssert(b.first == 1)
+        XCTAssert(b.dropFirst() == 1)
+        XCTAssert(b.dropFirst() == 2)
+        XCTAssert(b.dropFirst() == 3)
+        XCTAssert(b.dropFirst() == nil)
+        XCTAssert(b.first == nil)
+        XCTAssert(b.isEmpty)
+    }
+
+    func testLast() {
+        let a: RoaringBitmap = []
+        XCTAssert(a.last == nil)
+
+        let b: RoaringBitmap = [1, 2, 3]
+        XCTAssert(b.last == 3)
+        XCTAssert(b.dropLast() == 3)
+        XCTAssert(b.dropLast() == 2)
+        XCTAssert(b.dropLast() == 1)
+        XCTAssert(b.dropLast() == nil)
+        XCTAssert(b.last == nil)
+        XCTAssert(b.isEmpty)
     }
 }


### PR DESCRIPTION
isDisjoint is one of the methods that Swift SetAlgebra [implements automatically](https://developer.apple.com/documentation/swift/setalgebra/isdisjoint(with:)-4pgpn) however the automatic implementation constructs an intersection and checks the size of the new set. Using `roaring_bitmap_and_cardinality` directly avoids this extra allocation.