### PR TITLE
renamed dropFirst and dropLast to popFirst and popLast

### DIFF
--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -884,7 +884,7 @@ public final class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     @inlinable @inline(__always)
-    public func dropFirst() -> UInt32? {
+    public func popFirst() -> UInt32? {
         guard let first = self.first else { return nil }
         self.remove(first)
         return first
@@ -906,7 +906,7 @@ public final class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     }
 
     @inlinable @inline(__always)
-    public func dropLast() -> UInt32? {
+    public func popLast() -> UInt32? {
         guard let last = self.last else { return nil }
         self.remove(last)
         return last

--- a/Tests/swiftRoaringTests/swiftRoaringTests.swift
+++ b/Tests/swiftRoaringTests/swiftRoaringTests.swift
@@ -361,10 +361,10 @@ class swiftRoaringTests: XCTestCase {
         let b: RoaringBitmap = [1, 2, 3]
 
         XCTAssert(b.first == 1)
-        XCTAssert(b.dropFirst() == 1)
-        XCTAssert(b.dropFirst() == 2)
-        XCTAssert(b.dropFirst() == 3)
-        XCTAssert(b.dropFirst() == nil)
+        XCTAssert(b.popFirst() == 1)
+        XCTAssert(b.popFirst() == 2)
+        XCTAssert(b.popFirst() == 3)
+        XCTAssert(b.popFirst() == nil)
         XCTAssert(b.first == nil)
         XCTAssert(b.isEmpty)
     }
@@ -375,10 +375,10 @@ class swiftRoaringTests: XCTestCase {
 
         let b: RoaringBitmap = [1, 2, 3]
         XCTAssert(b.last == 3)
-        XCTAssert(b.dropLast() == 3)
-        XCTAssert(b.dropLast() == 2)
-        XCTAssert(b.dropLast() == 1)
-        XCTAssert(b.dropLast() == nil)
+        XCTAssert(b.popLast() == 3)
+        XCTAssert(b.popLast() == 2)
+        XCTAssert(b.popLast() == 1)
+        XCTAssert(b.popLast() == nil)
         XCTAssert(b.last == nil)
         XCTAssert(b.isEmpty)
     }


### PR DESCRIPTION
DropFirst is not the correct name for the function since [dropFirst](https://developer.apple.com/documentation/swift/string/dropfirst(_:)) technically returns a subsequence.

