### PR TITLE
Switch Codable encoding scheme from a base64-encoded string wrapped in an array to just a single base64-encoded string

### DIFF
--- a/Sources/SwiftRoaring/RoaringBitmap.swift
+++ b/Sources/SwiftRoaring/RoaringBitmap.swift
@@ -753,7 +753,7 @@ public final class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /// Encodable conformance
     ///
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.unkeyedContainer()
+        var container = encoder.singleValueContainer()
         let count = self.sizeInBytes()
         var data = Data(count: count)
 
@@ -768,7 +768,7 @@ public final class RoaringBitmap: Sequence, Equatable, CustomStringConvertible,
     /// Decodable conformance
     ///
     public init(from decoder: Decoder) throws {
-        var container = try decoder.unkeyedContainer()
+        let container = try decoder.singleValueContainer()
 
         let buffer = try container.decode(String.self)
         let data = Data(base64Encoded: buffer)

--- a/Tests/swiftRoaringTests/swiftRoaringTests.swift
+++ b/Tests/swiftRoaringTests/swiftRoaringTests.swift
@@ -332,7 +332,7 @@ class swiftRoaringTests: XCTestCase {
         let s = String(data: a, encoding: .utf8)!
         print(s.count)
         let b = try! dec.decode(RoaringBitmap.self, from: a)
-        let expected = "[\"AjowAAABAAAAAAAxABAAAAAAAAIABAAGAAgACgAMAA4AEAASABQAFgAYABoAHAAeACAAIgAkACYAKAAqACwALgAwADIANAA2ADgAOgA8AD4AQABCAEQARgBIAEoATABOAFAAUgBUAFYAWABaAFwAXgBgAGIA\"]"
+        let expected = "\"AjowAAABAAAAAAAxABAAAAAAAAIABAAGAAgACgAMAA4AEAASABQAFgAYABoAHAAeACAAIgAkACYAKAAqACwALgAwADIANAA2ADgAOgA8AD4AQABCAEQARgBIAEoATABOAFAAUgBUAFYAWABaAFwAXgBgAGIA\""
 
         XCTAssert(s == expected)
 


### PR DESCRIPTION
Fixes #23 